### PR TITLE
docs: Simplify example prompts and make spacing compact

### DIFF
--- a/local/README.md
+++ b/local/README.md
@@ -112,13 +112,9 @@ incidentfox> help
 
 ## Example Prompts
 
-incidentfox> Check if there are any pods crashing in the default namespace
-
-incidentfox> Investigate why the API service is returning 500 errors
-
-incidentfox> Analyze the performance of our payment service
-
-incidentfox> Find recent changes in the auth service
+incidentfox> Check if there are any k8s pods crashing
+incidentfox> Check if there's any grafana metric anomaly
+incidentfox> What GitHub PRs were merged in the last 24 hours?
 ```
 
 ## Configuration

--- a/local/incidentfox_cli/cli.py
+++ b/local/incidentfox_cli/cli.py
@@ -2452,21 +2452,11 @@ to specialized sub-agents:
 ## Example Prompts
 
 ```
-Check if there are any pods crashing in the default namespace
+Check if there are any k8s pods crashing
 ```
-
 ```
-Investigate why the API service is returning 500 errors
+Check if there's any grafana metric anomaly
 ```
-
-```
-Analyze the performance of our payment service
-```
-
-```
-Find recent changes in the auth service that might have caused issues
-```
-
 ```
 What GitHub PRs were merged in the last 24 hours?
 ```


### PR DESCRIPTION
## Summary
- Reduce example prompts from 5 to 3 focused examples (k8s pods, grafana metrics, GitHub PRs)
- Remove blank lines between prompts for more compact layout
- Update prompt wording to be more concise

## Test plan
- [ ] Verify `incidentfox help` command displays updated prompts correctly
- [ ] Confirm README displays prompts with compact spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)