### PR TITLE
fix(cli): Improve tool configuration restart robustness

### DIFF
--- a/local/incidentfox_cli/cli.py
+++ b/local/incidentfox_cli/cli.py
@@ -2960,7 +2960,9 @@ async def configure_kubernetes(session) -> bool:
                     console.print("[green]✓ K8S_ENABLED=true saved to .env[/green]")
                     restart_success = await restart_agent_service()
                     if restart_success:
-                        console.print("\n[green]✓ Kubernetes is now configured![/green]")
+                        console.print(
+                            "\n[green]✓ Kubernetes is now configured![/green]"
+                        )
                         return True
                     else:
                         console.print(


### PR DESCRIPTION
## Summary

Fixes critical bugs in the tool configuration flow where docker-compose restarts were failing silently, leading to misleading success messages and automatic retries with stale configuration.

**Changes:**
- Add `_find_local_dir()` helper to search docker-compose.yml in multiple locations (env var, ./local, cwd, __file__ fallback) - fixes packaged CLI path resolution
- Fix `restart_agent_service()` to return bool indicating success/failure instead of silently failing
- Update all configure_* functions (Kubernetes, AWS, GitHub, Slack, Generic) to check restart return value
- Show clear error messages when restart fails instead of misleading success messages

## Test plan
- ✅ Unit tests verify path resolution in all scenarios (env var, ./local, cwd, fallback)
- ✅ Docker restart success/failure properly returned
- ✅ Configuration functions return False when restart fails
- ✅ Manual configuration restart prompts on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)