### PR TITLE
feat(cli): Add shell escape with ! prefix for running bash commands

### DIFF
--- a/local/incidentfox_cli/cli.py
+++ b/local/incidentfox_cli/cli.py
@@ -1390,6 +1390,33 @@ async def run_repl(
             # Built-in commands
             cmd = prompt.lower()
 
+            # Shell escape: run bash commands with ! prefix
+            if prompt.startswith("!"):
+                shell_cmd = prompt[1:].strip()
+                if shell_cmd:
+                    try:
+                        console.print(f"[dim]$ {shell_cmd}[/dim]")
+                        result = subprocess.run(
+                            shell_cmd,
+                            shell=True,
+                            capture_output=True,
+                            text=True,
+                            cwd=os.getcwd(),
+                        )
+                        if result.stdout:
+                            console.print(result.stdout.rstrip())
+                        if result.stderr:
+                            console.print(f"[red]{result.stderr.rstrip()}[/red]")
+                        if result.returncode != 0:
+                            console.print(
+                                f"[yellow]Exit code: {result.returncode}[/yellow]"
+                            )
+                    except Exception as e:
+                        console.print(f"[red]Error running command: {e}[/red]")
+                else:
+                    console.print("[yellow]Usage: !<command> (e.g., !ls -la)[/yellow]")
+                continue
+
             # Basic commands: work with or without slash
             if cmd in ("quit", "exit", "q", "/quit", "/exit", "/q"):
                 console.print("[dim]Goodbye![/dim]")
@@ -2372,6 +2399,7 @@ def display_help():
 
 | Command | Description |
 |---------|-------------|
+| `!<cmd>` | Run a shell command (e.g., `!ls -la`, `!kubectl get pods`) |
 | `help` | Show this help |
 | `/config` | Show integration config status |
 | `/config <name>` | Configure an integration (e.g., `/config kubernetes`) |


### PR DESCRIPTION
Add shell escape feature that allows users to run bash commands directly from the CLI using the ! prefix, similar to Aider and Claude Code.

Users can now run commands like `!ls -la`, `!kubectl get pods`, `!git status` directly in the CLI prompt. Output is captured and displayed with proper formatting for stdout, stderr, and exit codes.

This follows common patterns from other code generation tools and provides a convenient way to interleave shell commands with agent interactions.

🤖 Generated with Claude Code