### PR TITLE
fix(ci): Remove dynamic step ID that caused workflow validation error

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -56,12 +56,6 @@ jobs:
             dockerfile: ./web_ui/Dockerfile
             image: incidentfox-web-ui
 
-    outputs:
-      agent-digest: ${{ steps.build-agent.outputs.digest }}
-      config-service-digest: ${{ steps.build-config-service.outputs.digest }}
-      orchestrator-digest: ${{ steps.build-orchestrator.outputs.digest }}
-      web-ui-digest: ${{ steps.build-web-ui.outputs.digest }}
-
     steps:
       - name: Check if service should be built
         id: should-build
@@ -107,12 +101,6 @@ jobs:
             ${{ env.ECR_REGISTRY }}/${{ matrix.image }}:${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
-
-      - name: Export digest
-        if: steps.should-build.outputs.build == 'true'
-        id: build-${{ matrix.service }}
-        run: |
-          echo "digest=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
 
       - name: Summary
         if: steps.should-build.outputs.build == 'true'


### PR DESCRIPTION
GitHub Actions doesn't allow expressions in step IDs. Removed the outputs section and dynamic step since they weren't being used.