### PR TITLE
fix(plugin): Use correct docker format string for older Docker versions

### DIFF
--- a/local/claude_code_pack/mcp-servers/incidentfox/src/incidentfox_mcp/tools/docker.py
+++ b/local/claude_code_pack/mcp-servers/incidentfox/src/incidentfox_mcp/tools/docker.py
@@ -40,7 +40,7 @@ def register_tools(mcp: FastMCP):
         Returns:
             JSON with container list.
         """
-        args = ["ps", "--format", "json"]
+        args = ["ps", "--format", "{{json .}}"]
         if all_containers:
             args.append("-a")
         if filter_name:
@@ -203,7 +203,7 @@ def register_tools(mcp: FastMCP):
         Returns:
             JSON with CPU, memory, network, and disk I/O stats.
         """
-        args = ["stats", "--no-stream", "--format", "json"]
+        args = ["stats", "--no-stream", "--format", "{{json .}}"]
         if container:
             args.append(container)
 
@@ -291,7 +291,7 @@ def register_tools(mcp: FastMCP):
         Returns:
             JSON with recent Docker events (container start/stop, etc.)
         """
-        args = ["events", "--since", since, "--format", "json"]
+        args = ["events", "--since", since, "--format", "{{json .}}"]
         if until:
             args.extend(["--until", until])
         else:


### PR DESCRIPTION
## Summary

Docker 20.10.x requires `{{json .}}` template format instead of `json` literal. The `json` format was only added in Docker 23.0+.

This fixes the following tools that were returning empty results on older Docker versions:
- `docker_ps`
- `docker_stats`
- `docker_events`

## Test plan

```bash
# Before: returns "json" literal
docker ps --format json

# After: returns actual JSON
docker ps --format "{{json .}}"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)