### PR TITLE
docs(plugin): Fix installation instructions and add install script

### DIFF
--- a/local/claude_code_pack/README.md
+++ b/local/claude_code_pack/README.md
@@ -17,11 +17,46 @@ A comprehensive SRE investigation toolkit for Claude Code. Bring production obse
 
 ## Quick Start
 
-```bash
-# Install the plugin
-claude plugin install /path/to/claude_code_pack
+### 1. Clone the repository
 
-# Create a service catalog (optional but recommended)
+```bash
+git clone https://github.com/incidentfox/incidentfox.git
+cd incidentfox/local/claude_code_pack
+```
+
+### 2. Install dependencies
+
+```bash
+cd mcp-servers/incidentfox
+uv sync
+cd ../..
+```
+
+### 3. Add the MCP server to Claude Code
+
+```bash
+# Add globally (available in all projects)
+claude mcp add-json incidentfox "$(cat <<EOF
+{
+  "command": "uv",
+  "args": ["--directory", "$(pwd)/mcp-servers/incidentfox", "run", "incidentfox-mcp"],
+  "env": {
+    "KUBECONFIG": "\${KUBECONFIG:-~/.kube/config}",
+    "AWS_REGION": "\${AWS_REGION:-us-east-1}",
+    "DATADOG_API_KEY": "\${DATADOG_API_KEY}",
+    "DATADOG_APP_KEY": "\${DATADOG_APP_KEY}"
+  }
+}
+EOF
+)" -s user
+
+# Verify it's working
+claude mcp list
+```
+
+### 4. (Optional) Create a service catalog
+
+```bash
 cat > .incidentfox.yaml << 'EOF'
 services:
   api-gateway:
@@ -36,11 +71,25 @@ known_issues:
     cause: "Database connection pool exhausted"
     solution: "Scale postgres replicas or increase pool size"
 EOF
-
-# Start investigating!
-claude
-> /incident API latency increased 5x
 ```
+
+### 5. Start investigating!
+
+```bash
+claude
+> What pods are running in the default namespace?
+> Help me investigate high latency in the payment service
+```
+
+### Alternative: Use with --plugin-dir (includes skills & commands)
+
+For the full experience with skills and commands:
+
+```bash
+claude --plugin-dir /path/to/claude_code_pack
+```
+
+This gives you access to `/incident`, `/metrics`, `/remediate` commands and the investigation skills.
 
 ## Configuration
 

--- a/local/claude_code_pack/install.sh
+++ b/local/claude_code_pack/install.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# IncidentFox Claude Code Plugin Installer
+# Usage: ./install.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MCP_DIR="$SCRIPT_DIR/mcp-servers/incidentfox"
+
+echo "Installing IncidentFox Claude Code Plugin..."
+echo ""
+
+# Check for required tools
+if ! command -v claude &> /dev/null; then
+    echo "Error: Claude Code CLI not found. Install it first:"
+    echo "  npm install -g @anthropic-ai/claude-code"
+    exit 1
+fi
+
+if ! command -v uv &> /dev/null; then
+    echo "Error: uv not found. Install it first:"
+    echo "  curl -LsSf https://astral.sh/uv/install.sh | sh"
+    exit 1
+fi
+
+# Install Python dependencies
+echo "Installing Python dependencies..."
+cd "$MCP_DIR"
+uv sync
+cd "$SCRIPT_DIR"
+
+# Add MCP server to Claude Code
+echo ""
+echo "Adding MCP server to Claude Code..."
+
+# Build the JSON config
+CONFIG=$(cat <<EOF
+{
+  "command": "uv",
+  "args": ["--directory", "$MCP_DIR", "run", "incidentfox-mcp"],
+  "env": {
+    "KUBECONFIG": "\${KUBECONFIG:-~/.kube/config}",
+    "AWS_REGION": "\${AWS_REGION:-us-east-1}",
+    "AWS_DEFAULT_REGION": "\${AWS_DEFAULT_REGION:-us-east-1}",
+    "DATADOG_API_KEY": "\${DATADOG_API_KEY}",
+    "DATADOG_APP_KEY": "\${DATADOG_APP_KEY}",
+    "PROMETHEUS_URL": "\${PROMETHEUS_URL}",
+    "ALERTMANAGER_URL": "\${ALERTMANAGER_URL}",
+    "ELASTICSEARCH_URL": "\${ELASTICSEARCH_URL}",
+    "LOKI_URL": "\${LOKI_URL}"
+  }
+}
+EOF
+)
+
+# Remove existing config if present
+claude mcp remove incidentfox -s user 2>/dev/null || true
+
+# Add new config
+claude mcp add-json incidentfox "$CONFIG" -s user
+
+echo ""
+echo "Verifying installation..."
+claude mcp list
+
+echo ""
+echo "============================================"
+echo "Installation complete!"
+echo "============================================"
+echo ""
+echo "The following tools are now available in Claude Code:"
+echo "  - Kubernetes: list_pods, get_pod_logs, get_pod_events, ..."
+echo "  - AWS: describe_ec2_instance, get_cloudwatch_logs, ..."
+echo "  - Datadog: query_datadog_metrics, search_datadog_logs, ..."
+echo "  - Docker: docker_ps, docker_logs, docker_inspect, ..."
+echo "  - Git: git_log, git_diff, correlate_with_deployment, ..."
+echo "  - And 30+ more!"
+echo ""
+echo "Quick test:"
+echo "  claude -p 'Use git_log to show the last 3 commits'"
+echo ""
+echo "For the full plugin experience (skills + commands):"
+echo "  claude --plugin-dir $SCRIPT_DIR"
+echo ""


### PR DESCRIPTION
## Summary

Fixes the installation documentation for open-source users.

### Changes:
- **Fixed Quick Start section** - Previous `claude plugin install` command doesn't exist
- **Added step-by-step guide** - Clone, install deps, add MCP server
- **Created `install.sh`** - One-command installation script
- **Documented `--plugin-dir`** - For full plugin experience with skills/commands

### For users:

```bash
# Clone and install
git clone https://github.com/incidentfox/incidentfox.git
cd incidentfox/local/claude_code_pack
./install.sh

# Or manually
cd mcp-servers/incidentfox && uv sync && cd ../..
claude mcp add-json incidentfox '{"command":"uv","args":["--directory","'$(pwd)'/mcp-servers/incidentfox","run","incidentfox-mcp"]}' -s user
```

## Test plan

- [x] `install.sh` runs successfully
- [x] `claude mcp list` shows incidentfox as connected
- [x] Tools work after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)