### PR TITLE
fix(plugin): Add missing dependencies for Slack, GitHub, PagerDuty, Sentry, and Elasticsearch tools

### DIFF
--- a/local/claude_code_pack/mcp-servers/incidentfox/pyproject.toml
+++ b/local/claude_code_pack/mcp-servers/incidentfox/pyproject.toml
@@ -10,6 +10,10 @@ dependencies = [
     "datadog-api-client>=2.20.0",
     "httpx>=0.25.0",
     "pyyaml>=6.0",
+    "slack-sdk>=3.27.0",
+    "PyGithub>=2.1.0",
+    "requests>=2.31.0",
+    "elasticsearch>=8.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Adds `slack-sdk>=3.27.0` for Slack integration tools
- Adds `PyGithub>=2.1.0` for GitHub integration tools
- Adds `requests>=2.31.0` for PagerDuty and Sentry tools
- Adds `elasticsearch>=8.0.0` for Elasticsearch log search

## Problem
Tools would fail at runtime with "package not installed" errors because the required Python packages were not listed in `pyproject.toml`.

Example error:
```
{"error": "slack-sdk not installed. Install with: pip install slack-sdk", "config_required": true}
```

## Note
`prophet` and `pandas` are intentionally excluded as they are heavy optional dependencies (~500MB, requires C compiler). The anomaly tools handle missing prophet gracefully with error messages suggesting manual installation.

## Test plan
- [ ] Run `uv sync` in `mcp-servers/incidentfox/`
- [ ] Verify Slack tools work: `slack_post_message`
- [ ] Verify GitHub tools work: `github_list_commits`
- [ ] Verify Elasticsearch tools work: `search_logs` with ES backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)