### PR TITLE
fix(web_ui): Add AGENT_SERVICE_URL to env.example for agent streaming

### DIFF
--- a/web_ui/env.example
+++ b/web_ui/env.example
@@ -5,7 +5,13 @@
 # - Via SSM tunnel to internal ALB:            http://localhost:8081
 CONFIG_SERVICE_URL=http://localhost:8080
 
+# Agent Service (multi-agent AI execution - Planner + sub-agents)
+# Used for /api/team/agent/stream endpoint (AgentRunnerModal)
+# Local dev: docker-compose maps agent service to 8081
+AGENT_SERVICE_URL=http://localhost:8081
+
 # Orchestrator (team provisioning control plane; internal-only)
+# Only used for admin operations, not for agent execution
 ORCHESTRATOR_URL=http://localhost:8070
 
 # RAPTOR Knowledge Base API (tree explorer, semantic search, Q&A)


### PR DESCRIPTION
## Summary
- Add `AGENT_SERVICE_URL=http://localhost:8081` to env.example
- Clarify comments about which service handles agent execution vs orchestration

## Problem
The AgentRunnerModal was showing "Not Found" errors when trying to run agents via the Quick Start wizard.

The stream route (`/api/team/agent/stream`) checks environment variables in this order:
1. `AGENT_SERVICE_URL`
2. `ORCHESTRATOR_URL`
3. Falls back to `http://localhost:8081`

Previously, env.example only had `ORCHESTRATOR_URL=http://localhost:8070` (for admin operations), so users who copied it to `.env.local` would have the route try to reach port 8070 instead of the agent service on 8081.

## Test plan
- [ ] Copy env.example to .env.local
- [ ] Run web_ui with `pnpm dev`
- [ ] Open Quick Start wizard and try "Run Your First Agent"
- [ ] Verify agent stream works and returns real agent responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)