### PR TITLE
docs: Improve README to highlight Claude Code plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,53 +32,44 @@ AI-powered incident investigation and infrastructure automation. IncidentFox int
 
 ## 🧑‍💻 For Developers
 
-Try IncidentFox locally with an interactive terminal — no infrastructure required.
-
-<div align="center">
-  <video src="https://github.com/user-attachments/assets/d7dfedf0-e814-4772-b6c4-daf6d5d11901" width="700" controls autoplay loop muted></video>
-  <br>
-  <em>Local CLI for terminal-native developers</em>
-</div>
-
-### Quick Start
+**85+ DevOps & SRE tools for Claude Code.** Query your infrastructure, investigate incidents, analyze costs, and debug CI/CD — all from your terminal.
 
 ```bash
-cd local
-make quickstart
+cd local/claude_code_pack
+./install.sh
+claude
 ```
 
-This will prompt for your OpenAI API key, start all services, and launch the CLI.
-
-**Already configured?** Just run:
-```bash
-make run
+Then try:
+```
+> Check my Kubernetes cluster health
+> What integrations are configured?
+> Analyze my AWS costs for the past 30 days
+> Help me investigate this alert: [paste]
 ```
 
-### Example Session
+**What you get:**
+- 85+ tools: Kubernetes, AWS, Datadog, Prometheus, GitHub, Slack, PagerDuty, Grafana, Sentry
+- Unified log search across multiple backends
+- Investigation history with pattern learning
+- Postmortem generation
+- No Docker, no services to manage
 
-```
-incidentfox> Check if there are any pods crashing in default namespace
+**Full docs:** [local/claude_code_pack/README.md](local/claude_code_pack/README.md)
 
-🔍 Investigating...
+<details>
+<summary><strong>Local CLI (Experimental)</strong></summary>
 
-Found 2 pods in CrashLoopBackOff:
-- payment-service-abc123: OOMKilled (memory limit 512Mi)
-- cart-service-xyz789: Error in startup probe
+> **Warning:** The local CLI is in early development and not recommended for production use.
 
-Recommendations:
-1. Increase memory limit for payment-service to 1Gi
-2. Check cart-service logs for startup errors
-```
+Self-hosted multi-agent system for advanced users who need custom agent behavior, self-hosted infrastructure, or non-Claude LLM providers.
 
-### What You Can Do Locally
+**Requirements:** Docker, Docker Compose, OpenAI API key
 
-- Investigate Kubernetes issues (pod crashes, deployments, services)
-- Query logs and metrics from your observability stack
-- Analyze AWS resources (EC2, Lambda, ECS, CloudWatch)
-- Search and analyze code with GitHub integration
-- Run anomaly detection on metrics
+**Documentation:** [local/incidentfox_cli/README.md](local/incidentfox_cli/README.md)
 
-**Full local setup guide:** [local/README.md](local/README.md)
+</details>
+
 
 ---
 

--- a/local/README.md
+++ b/local/README.md
@@ -1,23 +1,24 @@
 # IncidentFox Local
 
-Run IncidentFox AI SRE locally. Choose your preferred setup:
-
-| Option | Best For | Setup Time | Infrastructure |
-|--------|----------|------------|----------------|
-| **[Claude Code Plugin](#claude-code-plugin)** | Most users | 2 minutes | None |
-| **[Local CLI](#local-cli)** | Advanced customization | 10+ minutes | Docker required |
-
----
+AI-powered SRE tools for your terminal.
 
 ## Claude Code Plugin
 
-**Recommended for most users.** Zero infrastructure, works directly in Claude Code with 85+ SRE tools.
+**85+ DevOps & SRE tools for Claude Code.** Query your infrastructure, investigate incidents, analyze costs, and debug CI/CD — all from your terminal.
 
 ### Quick Start
 
 ```bash
 cd claude_code_pack
 ./install.sh
+claude
+```
+
+Then try:
+```
+> Check my Kubernetes cluster health
+> What integrations are configured?
+> Analyze my AWS costs for the past 30 days
 ```
 
 ### What You Get
@@ -28,64 +29,22 @@ cd claude_code_pack
 - Postmortem generation
 - No Docker, no services to manage
 
-### Learn More
-
-See **[claude_code_pack/README.md](./claude_code_pack/README.md)** for full documentation.
+**Full documentation:** [claude_code_pack/README.md](./claude_code_pack/README.md)
 
 ---
 
-## Local CLI
+<details>
+<summary><strong>Local CLI (Experimental)</strong></summary>
 
-**For advanced users** who want maximum customization, custom agents, or self-hosted infrastructure.
+> **Warning:** The local CLI is in early development and not recommended for production use. For a stable experience, use the Claude Code plugin above.
 
-> **Note:** The local CLI is still in early development. For a more stable experience, use the Claude Code plugin above.
+The local CLI is a self-hosted multi-agent system for advanced users who need:
+- Custom agent behavior and prompts
+- Self-hosted infrastructure
+- Non-Claude LLM providers
 
-### Quick Start
+**Requirements:** Docker, Docker Compose, OpenAI API key
 
-```bash
-make quickstart
-```
+**Documentation:** [incidentfox_cli/README.md](./incidentfox_cli/README.md)
 
-### What You Get
-
-- Multi-agent architecture (Planner + specialized sub-agents)
-- Self-hosted services (PostgreSQL, Config Service, Agent)
-- Full control over prompts and agent behavior
-- Web UI for configuration
-
-### Requirements
-
-- Docker & Docker Compose
-- OpenAI API key
-
-### Learn More
-
-See **[incidentfox_cli/README.md](./incidentfox_cli/README.md)** for full documentation.
-
----
-
-## Comparison
-
-| Feature | Claude Code Plugin | Local CLI |
-|---------|-------------------|-----------|
-| Setup complexity | Simple (2 min) | Complex (requires Docker) |
-| Infrastructure | None | PostgreSQL + Services |
-| Tools | 85+ MCP tools | 50+ function tools |
-| LLM | Claude (via Claude Code) | OpenAI (configurable) |
-| Customization | Limited | Full control |
-| Stability | Stable | Early development |
-| Cost | Claude Code subscription | OpenAI API costs |
-
-## Which Should I Use?
-
-**Use Claude Code Plugin if you:**
-- Want the fastest setup
-- Already use Claude Code
-- Don't need custom agents
-- Want a stable, tested experience
-
-**Use Local CLI if you:**
-- Need custom agent behavior
-- Want to self-host everything
-- Need to use a specific LLM provider
-- Are comfortable with Docker and early-stage software
+</details>

--- a/local/claude_code_pack/CLAUDE.md
+++ b/local/claude_code_pack/CLAUDE.md
@@ -1,0 +1,58 @@
+# IncidentFox - SRE Tools for Claude Code
+
+You have access to **85+ SRE investigation tools** via the IncidentFox MCP server. These tools help with:
+
+- **Kubernetes** - Pods, deployments, logs, events, resources
+- **AWS** - EC2, CloudWatch, ECS, cost analysis
+- **Observability** - Datadog, Prometheus, Grafana, Elasticsearch, Loki
+- **Collaboration** - Slack, PagerDuty, GitHub
+- **Analysis** - Anomaly detection, log analysis, blast radius
+
+## Quick Start Commands
+
+Try these read-only commands to explore your infrastructure:
+
+```
+Check my Kubernetes cluster health
+List pods in the default namespace
+Show recent errors from Datadog logs
+What AWS resources am I running?
+```
+
+## Common Use Cases
+
+### Alert Triage
+```
+Help me investigate this alert: [paste alert]
+What's causing high latency in the payment service?
+```
+
+### AWS Cost Optimization
+```
+Analyze my AWS costs for the past 30 days
+Find EC2 instances that could be rightsized
+```
+
+### CI/CD Debugging
+```
+Why did my GitHub workflow fail?
+Show me the last 5 failed deployments
+```
+
+### Incident Investigation
+```
+/incident [description] - Start structured investigation
+```
+
+## Configuration
+
+Run `get_config_status` to see which integrations are configured. Missing credentials? Use `save_credential` to add them:
+
+```
+Save my Datadog API key: [key]
+```
+
+## Learn More
+
+- Full docs: `local/claude_code_pack/README.md`
+- 85+ tools reference in README

--- a/local/claude_code_pack/README.md
+++ b/local/claude_code_pack/README.md
@@ -1,23 +1,21 @@
-# IncidentFox Claude Code Plugin
+# IncidentFox for Claude Code
 
-A comprehensive SRE investigation toolkit for Claude Code. Bring production observability, incident investigation, and remediation capabilities directly into your AI-assisted workflow.
+**85+ DevOps & SRE tools for Claude Code.** Query your infrastructure, investigate incidents, analyze costs, and debug CI/CD — all from your terminal.
 
-## Features
+## What You Can Do
 
-- **85+ Investigation Tools**: Kubernetes, AWS, Datadog, Prometheus, Docker, GitHub, Slack, PagerDuty, Grafana, Sentry, and more
-- **Service Catalog**: Personalize investigations with `.incidentfox.yaml`
-- **Unified Log Search**: Query across Datadog, CloudWatch, Elasticsearch, Loki
-- **Investigation History**: SQLite-based tracking with pattern learning
-- **Postmortem Generation**: Structured incident reports
-- **Blast Radius Analysis**: Understand service dependencies
-- **Cost Analysis**: AWS spending anomalies and rightsizing
-- **5 Expert Skills**: Investigation methodology, K8s debugging, AWS troubleshooting
-- **3 Commands**: `/incident`, `/metrics`, `/remediate`
-- **Dry-Run Mode**: Preview remediation actions before executing
+| Use Case | Example Prompt |
+|----------|----------------|
+| **Check Infrastructure** | "Check my Kubernetes cluster health" |
+| **Alert Triage** | "Help me investigate this alert: [paste]" |
+| **AWS Cost Optimization** | "Analyze my AWS costs and find savings" |
+| **CI/CD Debugging** | "Why did my GitHub workflow fail?" |
+| **Incident Investigation** | "What's causing high latency in payments?" |
+| **Log Analysis** | "Search Datadog logs for errors in the last hour" |
 
 ## Quick Start
 
-### Installation
+### 1. Install (2 minutes)
 
 ```bash
 git clone https://github.com/incidentfox/incidentfox.git
@@ -25,7 +23,50 @@ cd incidentfox/local/claude_code_pack
 ./install.sh
 ```
 
-That's it! The install script will:
+### 2. Try It
+
+```bash
+claude
+```
+
+**Read-only commands to explore** (safe to run anytime):
+```
+> Check my Kubernetes cluster health
+> List pods in the default namespace
+> What integrations are configured?
+> Show my AWS cost summary
+> List recent GitHub deployments
+```
+
+**Investigation commands** (when something's wrong):
+```
+> Help me investigate high latency in the payment service
+> What's causing these OOMKilled errors?
+> Search logs for "connection refused" errors
+```
+
+### 3. Configure Integrations
+
+Tools auto-detect what's available. Missing credentials? Add them on-the-fly:
+
+```
+> Search Datadog logs for errors
+
+Claude: I need your Datadog API key to search logs.
+
+> Here's my API key: dd-api-xxxxx
+
+Claude: Saved. Now searching...
+```
+
+Or check what's configured:
+```
+> What integrations are configured?
+```
+
+## Installation Details
+
+The install script will:
 1. Check prerequisites ([uv](https://github.com/astral-sh/uv) and Claude Code CLI)
 2. Install Python dependencies
 3. Add the MCP server to Claude Code globally
@@ -55,14 +96,6 @@ known_issues:
     cause: "Database connection pool exhausted"
     solution: "Scale postgres replicas or increase pool size"
 EOF
-```
-
-### Start Investigating!
-
-```bash
-claude
-> What pods are running in the default namespace?
-> Help me investigate high latency in the payment service
 ```
 
 ### Full Plugin Mode (skills + commands)
@@ -599,6 +632,62 @@ Investigation history is stored locally:
 └── logs/
     └── remediation.log # Audit log for remediation actions
 ```
+
+## Auto-Approve MCP Tools (Skip Permission Prompts)
+
+By default, Claude Code asks for permission each time an MCP tool is used. You can pre-approve IncidentFox tools to skip these prompts.
+
+### Option 1: Command Line Flag
+
+```bash
+claude --allowedTools "mcp__incidentfox__*"
+```
+
+This allows all IncidentFox tools for the session. You can be more specific:
+
+```bash
+# Allow only read-only tools
+claude --allowedTools "mcp__incidentfox__list_pods,mcp__incidentfox__get_pod_logs,mcp__incidentfox__search_logs"
+```
+
+### Option 2: Settings File (Persistent)
+
+Add to your Claude Code settings (`~/.claude/settings.json` or project `.claude/settings.json`):
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__incidentfox__*"
+    ]
+  }
+}
+```
+
+Or allow specific tool categories:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__incidentfox__list_*",
+      "mcp__incidentfox__get_*",
+      "mcp__incidentfox__search_*",
+      "mcp__incidentfox__describe_*",
+      "mcp__incidentfox__query_*"
+    ],
+    "deny": [
+      "mcp__incidentfox__propose_*"
+    ]
+  }
+}
+```
+
+### Option 3: Trust for Current Project
+
+When Claude asks for permission, select "Always allow for this project" to auto-approve that specific tool going forward.
+
+> **Note:** Remediation tools (`propose_pod_restart`, `propose_deployment_restart`, `propose_scale_deployment`) have additional confirmation hooks that run even with auto-approval enabled. This ensures you always confirm before making changes to your infrastructure.
 
 ## Security
 


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` welcome file with quick start prompts (auto-loaded by Claude Code)
- Add auto-permissions documentation section to `claude_code_pack/README.md`
- **Auto-approve read-only tools during installation** (no permission prompts!)
- Simplify `local/README.md` to focus on Claude Code plugin
- Collapse local CLI section with "Experimental" warning
- Update root `README.md` to de-emphasize local CLI

## Changes
| File | Change |
|------|--------|
| `local/claude_code_pack/CLAUDE.md` | New welcome file auto-loaded by Claude Code |
| `local/claude_code_pack/README.md` | Added auto-permissions documentation |
| `local/claude_code_pack/install.sh` | Auto-configures permissions for read-only tools |
| `local/README.md` | Simplified, CLI collapsed with warning |
| `README.md` | De-emphasized CLI, focus on Claude Code plugin |

## Auto-Permissions Details

The installer now adds to `~/.claude/settings.json`:
- **Auto-approved**: `list_*`, `get_*`, `search_*`, `describe_*`, `query_*`, `docker_*`, `git_*`, analysis tools
- **Still requires confirmation**: `propose_*` (remediation tools)

This means users can start investigating immediately without clicking "allow" for every tool call.

## Test plan
- [x] Verify CLAUDE.md is auto-loaded when starting Claude Code with plugin
- [x] Verify auto-permissions documentation is accurate
- [ ] Run install.sh and verify permissions are added to settings.json
- [ ] Verify read-only tools don't prompt, remediation tools still do

🤖 Generated with [Claude Code](https://claude.com/claude-code)