### PR TITLE
docs: Update README with demo video and simplified prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ AI-powered incident investigation and infrastructure automation. IncidentFox int
 
 **Claude Code plugin with ~100 DevOps & SRE tools, skills, and commands** to investigate incidents, analyze costs, and debug CI/CD — all from your terminal.
 
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/52d86ad1-6dc9-45e5-b80c-5f8a96b3dccd" width="700" controls autoplay loop muted></video>
+</p>
+
 ```bash
 cd local/claude_code_pack
 ./install.sh
@@ -52,13 +56,6 @@ claude
 > Find AWS costs over the last month and explore reduction opportunities
 > Why did my GitHub Actions workflow fail? [paste url]
 ```
-
-**What you get:**
-- 85+ tools: Kubernetes, AWS, Datadog, Prometheus, GitHub, Slack, PagerDuty, Grafana, Sentry
-- Unified log search across multiple backends
-- Investigation history with pattern learning
-- Postmortem generation
-- No Docker, no services to manage
 
 **Full docs:** [local/claude_code_pack/README.md](local/claude_code_pack/README.md)
 

--- a/local/README.md
+++ b/local/README.md
@@ -27,15 +27,7 @@ claude
 > Why did my GitHub Actions workflow fail? [paste url]
 ```
 
-### What You Get
-
-- 85+ investigation tools (Kubernetes, AWS, Datadog, Prometheus, GitHub, Slack, etc.)
-- Unified log search across multiple backends
-- Investigation history with pattern learning
-- Postmortem generation
-- No Docker, no services to manage
-
-**Full documentation:** [claude_code_pack/README.md](./claude_code_pack/README.md)
+**Full docs:** [claude_code_pack/README.md](./claude_code_pack/README.md)
 
 ---
 

--- a/local/claude_code_pack/README.md
+++ b/local/claude_code_pack/README.md
@@ -2,6 +2,10 @@
 
 **Claude Code plugin with ~100 DevOps & SRE tools, skills, and commands** to investigate incidents, analyze costs, and debug CI/CD — all from your terminal.
 
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/52d86ad1-6dc9-45e5-b80c-5f8a96b3dccd" width="700" controls autoplay loop muted></video>
+</p>
+
 ## What You Can Do
 
 | Use Case | Example Prompt |
@@ -25,15 +29,28 @@ cd incidentfox/local/claude_code_pack
 
 ### 2. Try It
 
+**Option A: MCP Tools Only**
 ```bash
 claude
 ```
+Gives you ~100 MCP tools for querying infrastructure, logs, metrics, etc.
+
+**Option B: Full Plugin (Recommended)**
+```bash
+claude --plugin-dir /path/to/incidentfox/local/claude_code_pack
+```
+Gives you everything in Option A, plus:
+- `/incident` — Start a structured investigation
+- `/metrics` — Query metrics from configured sources
+- `/remediate` — Propose and execute remediation actions
+- 5 expert skills (investigation methodology, K8s debugging, AWS troubleshooting, log analysis, SRE principles)
+
+---
 
 **Quick start** — explore your infrastructure (try whichever applies):
 ```
 > Check my Kubernetes cluster health
 > Show my Grafana dashboards
-> List pods in the default namespace
 ```
 
 **Real work** — use these tools for actual tasks:
@@ -41,7 +58,6 @@ claude
 > Help me triage this alert: [paste alert]
 > Find AWS costs over the last month and explore reduction opportunities
 > Why did my GitHub Actions workflow fail? [paste url]
-> Search logs for "connection refused" errors
 ```
 
 ### 3. Configure Integrations
@@ -96,20 +112,6 @@ known_issues:
     solution: "Scale postgres replicas or increase pool size"
 EOF
 ```
-
-### Full Plugin Mode (skills + commands)
-
-For the full experience including skills and slash commands:
-
-```bash
-claude --plugin-dir /path/to/claude_code_pack
-```
-
-This gives you access to:
-- `/incident` - Start a structured investigation
-- `/metrics` - Query metrics from configured sources
-- `/remediate` - Propose and execute remediation actions
-- 5 expert skills (investigation methodology, K8s debugging, etc.)
 
 ### Manual Installation
 


### PR DESCRIPTION
## Summary
- Add demo video to "For Developers" section
- Simplify quick start prompts (K8s, Grafana exploration)
- Add real work examples (alert triage, AWS cost, GitHub CI)
- Show Option A (MCP only) vs Option B (Full Plugin) in Try It section
- Remove redundant "What you get" section
- Update tagline to "~100 tools"

## Demo Video
<video src="https://github.com/user-attachments/assets/52d86ad1-6dc9-45e5-b80c-5f8a96b3dccd" width="400"></video>

🤖 Generated with [Claude Code](https://claude.com/claude-code)