### PR TITLE
fix(helm): Add AGENT_SERVICE_URL to web-ui deployment

### DIFF
--- a/charts/incidentfox/templates/web-ui.yaml
+++ b/charts/incidentfox/templates/web-ui.yaml
@@ -29,6 +29,8 @@ spec:
           env:
             - name: CONFIG_SERVICE_URL
               value: {{ required "global.configService.url is required" .Values.global.configService.url | quote }}
+            - name: AGENT_SERVICE_URL
+              value: {{ printf "http://incidentfox-agent.%s.svc.cluster.local:%d" .Values.namespace (.Values.services.agent.servicePort | int) | quote }}
             - name: ORCHESTRATOR_URL
               value: {{ printf "http://incidentfox-orchestrator.%s.svc.cluster.local:%d" .Values.namespace (.Values.services.orchestrator.servicePort | int) | quote }}
             # Ensure Next.js binds on all interfaces in Kubernetes (otherwise it may bind to pod hostname only,


### PR DESCRIPTION
## Summary
- Add `AGENT_SERVICE_URL` environment variable to web-ui Helm deployment
- Points to agent service for `/api/team/agent/stream` endpoint

## Problem
The web-ui's agent stream route checks environment variables in order:
1. `AGENT_SERVICE_URL` (was not set)
2. `ORCHESTRATOR_URL` (was set, pointing to orchestrator)
3. Falls back to `localhost:8081`

In EKS, `ORCHESTRATOR_URL` was set but the orchestrator doesn't have `/agents/*/run/stream` - that endpoint is on the **agent** service. This caused 404 errors in the AgentRunnerModal.

## Fix
Now `AGENT_SERVICE_URL` is set to point to `incidentfox-agent` service, so the stream route correctly calls the agent service.

## Test plan
- [ ] Deploy with `services: all` or `services: web-ui`
- [ ] Open Quick Start wizard in web UI
- [ ] Try "Run Your First Agent" 
- [ ] Verify streaming works without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)