### PR TITLE
fix(ci): Declare matrix variable explicitly to fix GHA validation

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -38,6 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        service: [agent, config-service, orchestrator, web-ui]
         include:
           - service: agent
             context: ./agent


### PR DESCRIPTION
## Summary
- Fixes GitHub Actions workflow validation error: `Unrecognized named-value: 'matrix'`
- Adds explicit `service` matrix variable declaration before `include:` block
- The validator requires explicit variable declarations to recognize `matrix.service` in expressions

## Test plan
- [ ] Verify workflow file passes GitHub Actions validation
- [ ] Trigger the deploy-eks workflow manually to confirm it runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)