### PR TITLE
fix(ci): Replace invalid --force-conflicts with --force in helm upgrade

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -147,7 +147,7 @@ jobs:
             -n ${{ env.HELM_NAMESPACE }} \
             -f incidentfox/values.prod.yaml \
             --no-hooks \
-            --force-conflicts \
+            --force \
             --wait \
             --timeout 10m
 


### PR DESCRIPTION
## Summary
- Fixes `Error: unknown flag: --force-conflicts` during Helm deploy
- `--force-conflicts` is a kubectl flag (server-side apply), not a Helm flag
- Replaced with `--force` which forces resource updates through delete/recreate strategy

## Test plan
- [ ] Re-run the deploy-eks workflow to verify Helm upgrade succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)