### PR TITLE
fix: prevent login UI hang with timeouts and optimize DB performance

### DIFF
--- a/config_service/src/db/repository.py
+++ b/config_service/src/db/repository.py
@@ -409,9 +409,16 @@ def authenticate_org_admin_token(
     if row.is_expired():
         raise ValueError("Token has expired")
 
+    # Throttle last_used_at updates to reduce write contention (only update if older than 5 minutes)
     if update_last_used:
-        row.last_used_at = datetime.utcnow()
-        session.flush()
+        now = datetime.utcnow()
+        should_update = (
+            row.last_used_at is None
+            or (now - row.last_used_at.replace(tzinfo=None)).total_seconds() > 300
+        )
+        if should_update:
+            row.last_used_at = now
+            session.flush()
 
     return OrgAdminPrincipal(org_id=row.org_id)
 
@@ -689,10 +696,16 @@ def authenticate_bearer_token(
         )
         raise ValueError("Token expired")
 
-    # Update last_used_at
+    # Update last_used_at (throttled to reduce write contention - only update if older than 5 minutes)
     if update_last_used:
-        row.last_used_at = datetime.utcnow()
-        session.flush()
+        now = datetime.utcnow()
+        should_update = (
+            row.last_used_at is None
+            or (now - row.last_used_at.replace(tzinfo=None)).total_seconds() > 300
+        )
+        if should_update:
+            row.last_used_at = now
+            session.flush()
 
     return Principal(org_id=row.org_id, team_node_id=row.team_node_id)
 

--- a/config_service/src/db/session.py
+++ b/config_service/src/db/session.py
@@ -79,7 +79,17 @@ def _is_local_tunnel_up(url: str) -> bool:
 
 
 def make_engine():
-    return create_engine(get_database_url(), pool_pre_ping=True)
+    return create_engine(
+        get_database_url(),
+        pool_pre_ping=True,
+        pool_size=20,
+        max_overflow=40,
+        pool_recycle=3600,
+        connect_args={
+            "connect_timeout": 10,
+            "options": "-c statement_timeout=30000",  # 30 second query timeout
+        },
+    )
 
 
 _SessionLocal: Optional[sessionmaker] = None


### PR DESCRIPTION
## Summary
- **Web UI**: Add 15-second timeouts to login and identity refresh fetches to prevent the UI from hanging indefinitely when the config service is slow/unresponsive
- **Config Service**: Optimize database connection pool and reduce write contention from `last_used_at` updates

## Problem
When logging in via the web UI, the "Signing in..." state would hang forever if the upstream config service was slow or unresponsive. This was disruptive to UX.

## Root Causes
1. No timeout on login fetch - could hang indefinitely
2. No timeout on identity refresh - could hang indefinitely  
3. Config service connection pool too small (5 default) - exhausts under load
4. No connection/query timeouts - can hang on DB issues
5. `last_used_at` UPDATE on every token auth - creates write contention

## Changes

### Web UI
- `SignInGate.tsx`: Add 15s timeout with AbortController to login fetch
- `useIdentity.ts`: Add 15s timeout with AbortController to identity refresh
- User-friendly timeout error messages

### Config Service
- `session.py`: Increase pool_size to 20, max_overflow to 40, add 10s connect timeout, 30s query timeout, 1hr pool recycle
- `repository.py`: Throttle `last_used_at` updates to 5-minute intervals (reduces writes ~99% for active tokens)

## Test plan
- [ ] Verify login works normally when config service is responsive
- [ ] Verify timeout error appears after 15s when config service is unresponsive
- [ ] Verify "Continue" button returns to normal state after timeout
- [ ] Verify token auth still works with throttled `last_used_at` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)