### PR TITLE
fix(ci): Add kubectl verification step to debug EKS auth

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -135,6 +135,11 @@ jobs:
         run: |
           aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER }} --region ${{ env.AWS_REGION }}
 
+      - name: Verify cluster access
+        run: |
+          kubectl cluster-info
+          kubectl get nodes
+
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:


### PR DESCRIPTION
## Summary
- Adds `kubectl cluster-info` and `kubectl get nodes` verification before Helm deploy
- Helps diagnose the "client to provide credentials" authentication error
- If this step fails, the issue is with AWS/EKS IAM permissions, not Helm

## Test plan
- [ ] Re-run deploy-eks workflow
- [ ] If verification step fails, check IAM permissions for the AWS credentials
- [ ] If verification passes but Helm fails, investigate further

🤖 Generated with [Claude Code](https://claude.com/claude-code)