### PR TITLE
fix(ci): Add AWS identity debug step for EKS auth

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -131,6 +131,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Show AWS identity (for aws-auth debugging)
+        run: |
+          echo "=== AWS Caller Identity ==="
+          aws sts get-caller-identity
+          echo ""
+          echo "Add the above ARN to your EKS aws-auth ConfigMap if not already present"
+
       - name: Update kubeconfig
         run: |
           aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER }} --region ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary
- Adds `aws sts get-caller-identity` step to show the IAM ARN being used
- This ARN needs to be added to the EKS cluster's `aws-auth` ConfigMap

## Next Steps After Merging
1. Re-run the workflow to see the IAM ARN in the logs
2. Someone with cluster access needs to run:
   ```bash
   kubectl edit configmap aws-auth -n kube-system
   ```
3. Add the IAM user/role to the `mapUsers` or `mapRoles` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)