### PR TITLE
fix(ci): Increase rollout timeout from 5m to 10m

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -180,12 +180,12 @@ jobs:
       - name: Wait for rollout
         run: |
           if [ "${{ github.event.inputs.services }}" = "all" ]; then
-            kubectl rollout status deployment/incidentfox-agent -n ${{ env.HELM_NAMESPACE }} --timeout=5m
-            kubectl rollout status deployment/incidentfox-config-service -n ${{ env.HELM_NAMESPACE }} --timeout=5m
-            kubectl rollout status deployment/incidentfox-orchestrator -n ${{ env.HELM_NAMESPACE }} --timeout=5m
-            kubectl rollout status deployment/incidentfox-web-ui -n ${{ env.HELM_NAMESPACE }} --timeout=5m
+            kubectl rollout status deployment/incidentfox-agent -n ${{ env.HELM_NAMESPACE }} --timeout=10m
+            kubectl rollout status deployment/incidentfox-config-service -n ${{ env.HELM_NAMESPACE }} --timeout=10m
+            kubectl rollout status deployment/incidentfox-orchestrator -n ${{ env.HELM_NAMESPACE }} --timeout=10m
+            kubectl rollout status deployment/incidentfox-web-ui -n ${{ env.HELM_NAMESPACE }} --timeout=10m
           else
-            kubectl rollout status deployment/incidentfox-${{ github.event.inputs.services }} -n ${{ env.HELM_NAMESPACE }} --timeout=5m
+            kubectl rollout status deployment/incidentfox-${{ github.event.inputs.services }} -n ${{ env.HELM_NAMESPACE }} --timeout=10m
           fi
 
       - name: Verify deployment


### PR DESCRIPTION
## Summary
- Increases `kubectl rollout status` timeout from 5m to 10m
- ECR image pulls can take 2-4 minutes, causing the 5m timeout to be exceeded
- The deployment actually succeeded, but the wait timed out

## Root Cause
From cluster events:
```
Successfully pulled image "...incidentfox-agent:latest" in 3m42.75s
Successfully pulled image "...incidentfox-orchestrator:latest" in 2m29.103s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)