### PR TITLE
fix: Add missing RAPTOR_API_URL to web-ui deployment

### DIFF
--- a/charts/incidentfox/templates/web-ui.yaml
+++ b/charts/incidentfox/templates/web-ui.yaml
@@ -33,6 +33,10 @@ spec:
               value: {{ printf "http://incidentfox-agent.%s.svc.cluster.local:%d" .Values.namespace (.Values.services.agent.servicePort | int) | quote }}
             - name: ORCHESTRATOR_URL
               value: {{ printf "http://incidentfox-orchestrator.%s.svc.cluster.local:%d" .Values.namespace (.Values.services.orchestrator.servicePort | int) | quote }}
+            {{- if .Values.services.webUi.raptorApiUrl }}
+            - name: RAPTOR_API_URL
+              value: {{ .Values.services.webUi.raptorApiUrl | quote }}
+            {{- end }}
             # Ensure Next.js binds on all interfaces in Kubernetes (otherwise it may bind to pod hostname only,
             # which breaks kubectl port-forward and can confuse health checks).
             - name: HOSTNAME

--- a/charts/incidentfox/values.prod.yaml
+++ b/charts/incidentfox/values.prod.yaml
@@ -154,6 +154,8 @@ services:
     enabled: true
     image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-web-ui:latest"
     cookieSecure: true
+    # RAPTOR Knowledge Base API for tree explorer and semantic search
+    raptorApiUrl: "http://incidentfox-knowledge-base.incidentfox.svc.cluster.local:8000"
     oidc:
       enabled: false
     slack:

--- a/charts/incidentfox/values.yaml
+++ b/charts/incidentfox/values.yaml
@@ -274,6 +274,10 @@ services:
     image: "incidentfox/web-ui:v1.0.0"
     replicas: 2
     servicePort: 3000
+    # RAPTOR Knowledge Base API URL (for tree explorer, semantic search, Q&A)
+    # If using the incidentfox-knowledge-base service in same namespace:
+    # raptorApiUrl: "http://incidentfox-knowledge-base.incidentfox.svc.cluster.local:8000"
+    raptorApiUrl: ""
     resources:
       requests:
         cpu: "100m"


### PR DESCRIPTION
## Summary
The web-ui was failing with ECONNREFUSED when calling the knowledge base API because the RAPTOR_API_URL environment variable was missing. This caused it to default to localhost:8000, which doesn't exist in EKS, resulting in 500 errors on /api/team/knowledge/tree/stats.

## Changes
- Added RAPTOR_API_URL env var to web-ui Helm template with conditional rendering
- Configured raptorApiUrl in values.yaml (default empty) and values.prod.yaml (points to internal service)
- The service URL points to incidentfox-knowledge-base in the incidentfox namespace on port 8000

🤖 Generated with Claude Code