### PR TITLE
fix: Quick Start modal showing repeatedly

### DIFF
--- a/web_ui/src/app/api/team/preferences/route.ts
+++ b/web_ui/src/app/api/team/preferences/route.ts
@@ -23,7 +23,7 @@ export async function GET(req: NextRequest) {
     }
 
     const config = await res.json();
-    const preferences = config?.preferences || {};
+    const preferences = config?.effective_config?.preferences || {};
 
     return NextResponse.json(preferences);
   } catch (err: unknown) {
@@ -78,7 +78,7 @@ export async function PATCH(req: NextRequest) {
     }
 
     const result = await res.json();
-    return NextResponse.json(result?.preferences || preferences);
+    return NextResponse.json(result?.config?.preferences || preferences);
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- Fix preferences route reading from wrong path in backend response
- GET was reading `config?.preferences` but backend returns `effective_config.preferences`
- PATCH was reading `result?.preferences` but backend returns `config.preferences`

This caused the Quick Start modal to show on every page load because `welcomeModalSeen` was never read correctly.

## Test plan
- [ ] Deploy to staging
- [ ] Log in as a new user → Quick Start modal should appear
- [ ] Click "Skip tutorial" → modal closes
- [ ] Refresh the page → modal should NOT appear again
- [ ] Clear localStorage and refresh → modal should still NOT appear (persisted in backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)