### PR TITLE
fix(web_ui): Apply UI color improvements (cyan MCP, orange headers)

### DIFF
--- a/web_ui/src/app/admin/config/page.tsx
+++ b/web_ui/src/app/admin/config/page.tsx
@@ -925,7 +925,7 @@ export default function AdminConfigPage() {
                         }}
                         className="w-full px-4 py-3 text-left hover:bg-slate-700 transition-colors rounded-b-lg flex items-center gap-3"
                       >
-                        <ExternalLink className="w-4 h-4 text-purple-500" />
+                        <ExternalLink className="w-4 h-4 text-cyan-500" />
                         <div>
                           <div className="text-sm font-medium text-white">Add Remote A2A Agent</div>
                           <div className="text-xs text-slate-400">Integrate external AI agent</div>
@@ -1134,7 +1134,7 @@ export default function AdminConfigPage() {
                           const hasSubAgents = Object.keys(subAgents).length > 0;
                           return hasSubAgents && (
                             <div className="flex items-center gap-2">
-                              <span className="text-xs px-2 py-1 rounded-full bg-purple-900/30 text-purple-400 flex items-center gap-1">
+                              <span className="text-xs px-2 py-1 rounded-full bg-cyan-900/30 text-cyan-400 flex items-center gap-1">
                                 <Sparkles className="w-3 h-3" />
                                 Orchestrator
                               </span>
@@ -1222,7 +1222,7 @@ export default function AdminConfigPage() {
                           <div className="bg-slate-800 rounded-xl p-4 border border-slate-700">
                             <div className="flex items-center justify-between mb-4">
                               <div className="flex items-center gap-2">
-                                <Brain className="w-5 h-5 text-purple-500" />
+                                <Brain className="w-5 h-5 text-cyan-500" />
                                 <h3 className="font-semibold text-white">
                                   System Prompt
                                 </h3>
@@ -1431,7 +1431,7 @@ export default function AdminConfigPage() {
                                             <span className="text-lg leading-none">+</span>
                                             {tool.name}
                                             {tool.source === 'mcp' && (
-                                              <span className="text-[10px] px-1 py-0.5 rounded bg-purple-900/30 text-purple-400">
+                                              <span className="text-[10px] px-1 py-0.5 rounded bg-cyan-900/30 text-cyan-400">
                                                 MCP
                                               </span>
                                             )}
@@ -1479,7 +1479,7 @@ export default function AdminConfigPage() {
                           <div className="bg-slate-800 rounded-xl p-4 border border-slate-700">
                             <div className="flex items-center justify-between mb-4">
                               <div className="flex items-center gap-2">
-                                <Server className="w-5 h-5 text-purple-500" />
+                                <Server className="w-5 h-5 text-cyan-500" />
                                 <h3 className="font-semibold text-white">
                                   MCP Servers
                                 </h3>
@@ -1529,7 +1529,7 @@ export default function AdminConfigPage() {
                                                   }
                                                 });
                                               }}
-                                              className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg transition-colors group bg-purple-500 text-white hover:bg-purple-600"
+                                              className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg transition-colors group bg-cyan-500 text-white hover:bg-cyan-600"
                                               title={`Click to remove (${toolCount} tools)`}
                                             >
                                               <Server className="w-4 h-4" />
@@ -1571,7 +1571,7 @@ export default function AdminConfigPage() {
                                                       }
                                                     });
                                                   }}
-                                                  className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg transition-colors bg-slate-700 border border-slate-600 text-slate-300 hover:border-purple-500 hover:text-purple-400"
+                                                  className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg transition-colors bg-slate-700 border border-slate-600 text-slate-300 hover:border-cyan-500 hover:text-cyan-400"
                                                   title={`Click to add (${toolCount} tools)`}
                                                 >
                                                   <Server className="w-4 h-4" />
@@ -1669,7 +1669,7 @@ export default function AdminConfigPage() {
                                               }}
                                               className={`flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg transition-colors group ${
                                                 isRemote
-                                                  ? 'bg-purple-500 text-white hover:bg-purple-600'
+                                                  ? 'bg-cyan-500 text-white hover:bg-cyan-600'
                                                   : 'bg-orange-500 text-white hover:bg-orange-600'
                                               }`}
                                               title={isRemote ? 'Remote A2A Agent - Click to remove' : 'Local Agent - Click to remove'}
@@ -1718,7 +1718,7 @@ export default function AdminConfigPage() {
                                                   }}
                                                   className={`flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-lg border border-dashed transition-colors ${
                                                     isRemote
-                                                      ? 'border-purple-600 text-purple-400 hover:border-purple-400 hover:text-purple-300'
+                                                      ? 'border-cyan-600 text-cyan-400 hover:border-cyan-400 hover:text-cyan-300'
                                                       : 'border-slate-600 text-slate-400 hover:border-indigo-400 hover:text-indigo-400'
                                                   }`}
                                                   title={isRemote ? 'Remote A2A Agent - Click to add' : 'Local Agent - Click to add'}
@@ -1833,7 +1833,7 @@ export default function AdminConfigPage() {
                                       {tool.required_integrations.map((int) => (
                                         <span
                                           key={int}
-                                          className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-purple-900/30 text-purple-400"
+                                          className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-cyan-900/30 text-cyan-400"
                                         >
                                           {int}
                                         </span>
@@ -1973,7 +1973,7 @@ export default function AdminConfigPage() {
                           <span className="font-semibold text-white">{schema.name}</span>
                           <span className={`px-2 py-0.5 text-xs rounded ${
                             schema.level === 'org' 
-                              ? 'bg-purple-900/50 text-purple-400' 
+                              ? 'bg-purple-900/50 text-cyan-400' 
                               : 'bg-cyan-900/50 text-cyan-400'
                           }`}>
                             {schema.level}-level
@@ -2076,7 +2076,7 @@ export default function AdminConfigPage() {
               {/* Org-level fields */}
               {integrationSchemas[editingIntegration].org_fields.length > 0 && (
                 <div>
-                  <h3 className="text-sm font-medium text-purple-400 mb-4 flex items-center gap-2">
+                  <h3 className="text-sm font-medium text-cyan-400 mb-4 flex items-center gap-2">
                     <span className="w-2 h-2 bg-purple-400 rounded-full" />
                     Organization Settings
                   </h3>
@@ -2308,7 +2308,7 @@ export default function AdminConfigPage() {
           <div className="bg-slate-900 border border-slate-700 rounded-xl shadow-2xl w-full max-w-2xl mx-4 p-6 max-h-[90vh] overflow-y-auto">
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-2">
-                <ExternalLink className="w-5 h-5 text-purple-500" />
+                <ExternalLink className="w-5 h-5 text-cyan-500" />
                 <h3 className="text-lg font-semibold text-white">
                   Add Remote A2A Agent
                 </h3>
@@ -2681,7 +2681,7 @@ export default function AdminConfigPage() {
                       }
                     }}
                     disabled={!newRemoteAgent.id || !newRemoteAgent.name || !newRemoteAgent.url || saving}
-                    className="px-4 py-2 text-sm bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50"
+                    className="px-4 py-2 text-sm bg-cyan-600 text-white rounded-lg hover:bg-cyan-700 disabled:opacity-50"
                   >
                     {saving ? (
                       <span className="flex items-center gap-2">

--- a/web_ui/src/app/admin/defaults/page.tsx
+++ b/web_ui/src/app/admin/defaults/page.tsx
@@ -458,7 +458,7 @@ export default function OrgDefaultsPage() {
             {/* MCP List */}
             {mcpServers.length === 0 ? (
               <div className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-12 text-center">
-                <Server className="w-12 h-12 mx-auto text-gray-300 dark:text-gray-600 mb-4" />
+                <Server className="w-12 h-12 mx-auto text-cyan-300 dark:text-cyan-600 mb-4" />
                 <p className="text-gray-500">No default MCP servers configured.</p>
                 <p className="text-xs text-gray-400 mt-2">
                   Add MCP servers that all teams will inherit by default.
@@ -476,8 +476,8 @@ export default function OrgDefaultsPage() {
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
-                        <Server className="w-5 h-5 text-gray-600" />
+                      <div className="w-10 h-10 rounded-lg bg-cyan-100 dark:bg-cyan-900/30 flex items-center justify-center">
+                        <Server className="w-5 h-5 text-cyan-600" />
                       </div>
                       <div>
                         <div className="flex items-center gap-2">

--- a/web_ui/src/app/admin/templates/page.tsx
+++ b/web_ui/src/app/admin/templates/page.tsx
@@ -288,7 +288,7 @@ export default function AdminTemplatesPage() {
                     {template.required_mcps.slice(0, 3).map((mcp) => (
                       <span
                         key={mcp}
-                        className="text-xs px-2 py-1 bg-purple-900/30 text-purple-400 rounded"
+                        className="text-xs px-2 py-1 bg-cyan-900/30 text-cyan-400 rounded"
                       >
                         {mcp}
                       </span>
@@ -378,7 +378,7 @@ export default function AdminTemplatesPage() {
                     {selectedTemplate.required_mcps.map((mcp) => (
                       <span
                         key={mcp}
-                        className="px-3 py-1 bg-purple-900/30 text-purple-400 rounded-lg text-sm border border-purple-800/50"
+                        className="px-3 py-1 bg-cyan-900/30 text-cyan-400 rounded-lg text-sm border border-cyan-800/50"
                       >
                         {mcp}
                       </span>

--- a/web_ui/src/app/team/agent-runs/page.tsx
+++ b/web_ui/src/app/team/agent-runs/page.tsx
@@ -151,17 +151,21 @@ export default function TeamAgentRunsPage() {
   return (
     <div className="p-8 max-w-5xl mx-auto">
       <div className="flex items-center justify-between mb-8">
-        <div>
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white flex items-center gap-3">
-            <Activity className="w-7 h-7 text-gray-500" />
-            Agent Run History
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center">
+            <Activity className="w-5 h-5 text-white" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+              Agent Run History
             <HelpTip id="agent-runs" position="right">
               <strong>Agent Runs</strong> are individual AI investigation sessions. Each run uses tools like Grafana, Kubernetes, and your Knowledge Base to analyze incidents and provide recommendations.
             </HelpTip>
           </h1>
-          <p className="text-sm text-gray-500 mt-1">
-            View the history of AI agent invocations for your team.
-          </p>
+            <p className="text-sm text-gray-500">
+              View the history of AI agent invocations for your team.
+            </p>
+          </div>
         </div>
         <div className="flex items-center gap-3">
           {runningCount > 0 && (

--- a/web_ui/src/app/team/agents/page.tsx
+++ b/web_ui/src/app/team/agents/page.tsx
@@ -587,8 +587,8 @@ export default function AgentSettingsPage() {
       <div className="flex-shrink-0 px-8 py-6 border-b border-gray-200 dark:border-gray-800">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <div className="w-12 h-12 rounded-xl bg-gray-800 flex items-center justify-center">
-              <Brain className="w-6 h-6 text-gray-300" />
+            <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center">
+              <Brain className="w-6 h-6 text-white" />
             </div>
             <div>
               <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
@@ -1340,7 +1340,7 @@ export default function AgentSettingsPage() {
                 <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4 border border-gray-200 dark:border-gray-800">
                   <div className="flex items-center justify-between mb-4">
                     <div className="flex items-center gap-2">
-                      <Server className="w-5 h-5 text-purple-500" />
+                      <Server className="w-5 h-5 text-cyan-500" />
                       <h3 className="font-semibold text-gray-900 dark:text-white">
                         MCP Servers
                       </h3>
@@ -1390,7 +1390,7 @@ export default function AgentSettingsPage() {
                                         }
                                       });
                                     }}
-                                    className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg transition-colors group bg-purple-500 text-white hover:bg-purple-600"
+                                    className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg transition-colors group bg-cyan-500 text-white hover:bg-cyan-600"
                                     title={`Click to remove (${toolCount} tools)`}
                                   >
                                     <Server className="w-4 h-4" />
@@ -1432,7 +1432,7 @@ export default function AgentSettingsPage() {
                                             }
                                           });
                                         }}
-                                        className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg transition-colors bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-purple-500 hover:text-purple-600 dark:hover:text-purple-400"
+                                        className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg transition-colors bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-cyan-500 hover:text-cyan-600 dark:hover:text-cyan-400"
                                         title={`Click to add (${toolCount} tools)`}
                                       >
                                         <Server className="w-4 h-4" />
@@ -1448,7 +1448,7 @@ export default function AgentSettingsPage() {
 
                           {availableMcps.length === 0 && (
                             <div className="text-sm text-gray-500 italic">
-                              No MCP servers available. Configure them in the <a href="/team/tools" className="text-purple-600 hover:underline">Tools page</a>.
+                              No MCP servers available. Configure them in the <a href="/team/tools" className="text-cyan-600 hover:underline">Tools page</a>.
                             </div>
                           )}
                         </>

--- a/web_ui/src/app/team/page.tsx
+++ b/web_ui/src/app/team/page.tsx
@@ -277,7 +277,7 @@ export default function TeamDashboardPage() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Bot className="w-7 h-7 text-gray-600 dark:text-gray-400" />
+            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center"><Bot className="w-5 h-5 text-white" /></div>
             <div>
               <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Team Dashboard</h1>
               <p className="text-sm text-gray-500">Monitor your AI agents and team activity</p>

--- a/web_ui/src/app/team/pending-changes/page.tsx
+++ b/web_ui/src/app/team/pending-changes/page.tsx
@@ -224,14 +224,18 @@ export default function TeamPendingChangesPage() {
   return (
     <div className="p-8 max-w-4xl mx-auto">
       <div className="flex items-center justify-between mb-8">
-        <div>
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white flex items-center gap-3">
-            <GitPullRequest className="w-7 h-7 text-gray-500" />
-            Proposed Changes
-          </h1>
-          <p className="text-sm text-gray-500 mt-1">
-            Review and approve AI-proposed changes to your team's configuration.
-          </p>
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center">
+            <GitPullRequest className="w-5 h-5 text-white" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+              Proposed Changes
+            </h1>
+            <p className="text-sm text-gray-500">
+              Review and approve AI-proposed changes to your team's configuration.
+            </p>
+          </div>
         </div>
         {pendingCount > 0 && (
           <div className="flex items-center gap-2 px-3 py-1.5 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-400 rounded-full text-sm font-medium">

--- a/web_ui/src/app/team/prompts/page.tsx
+++ b/web_ui/src/app/team/prompts/page.tsx
@@ -291,14 +291,18 @@ export default function TeamPromptsPage() {
   return (
     <div className="p-8 max-w-5xl mx-auto">
       <div className="flex items-center justify-between mb-8">
-        <div>
-          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white flex items-center gap-3">
-            <MessageSquareText className="w-7 h-7 text-gray-500" />
-            Agent Prompts
-          </h1>
-          <p className="text-sm text-gray-500 mt-1">
-            Customize system prompts for your team's AI agents.
-          </p>
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center">
+            <MessageSquareText className="w-5 h-5 text-white" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+              Agent Prompts
+            </h1>
+            <p className="text-sm text-gray-500">
+              Customize system prompts for your team's AI agents.
+            </p>
+          </div>
         </div>
       </div>
 

--- a/web_ui/src/app/team/templates/page.tsx
+++ b/web_ui/src/app/team/templates/page.tsx
@@ -181,14 +181,18 @@ export default function TemplatesPage() {
       {/* Header */}
       <div className="mb-8">
         <div className="flex items-center justify-between mb-4">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white flex items-center gap-3">
-              <LayoutTemplate className="w-8 h-8 text-gray-600 dark:text-gray-400" />
-              Template Marketplace
-            </h1>
-            <p className="text-gray-600 dark:text-gray-400 mt-2">
-              Pre-configured agent systems optimized for specific use cases
-            </p>
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center">
+              <LayoutTemplate className="w-6 h-6 text-white" />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+                Template Marketplace
+              </h1>
+              <p className="text-gray-600 dark:text-gray-400">
+                Pre-configured agent systems optimized for specific use cases
+              </p>
+            </div>
           </div>
         </div>
 

--- a/web_ui/src/app/team/tools/page.tsx
+++ b/web_ui/src/app/team/tools/page.tsx
@@ -897,7 +897,7 @@ export default function TeamToolsPage() {
                     return (
                       <span
                         key={idx}
-                        className="text-[10px] px-1.5 py-0.5 rounded bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300"
+                        className="text-[10px] px-1.5 py-0.5 rounded bg-cyan-50 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300"
                         title={toolDesc}
                       >
                         {toolName}
@@ -1007,8 +1007,8 @@ export default function TeamToolsPage() {
       <div className="flex-shrink-0 px-8 py-6 border-b border-gray-200 dark:border-gray-800">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <div className="w-11 h-11 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
-              <Wrench className="w-5 h-5 text-gray-600 dark:text-gray-400" />
+            <div className="w-11 h-11 rounded-xl bg-gradient-to-br from-orange-500 to-amber-500 flex items-center justify-center">
+              <Wrench className="w-5 h-5 text-white" />
             </div>
             <div>
               <h1 className="text-xl font-semibold text-gray-900 dark:text-white">Tools</h1>
@@ -1111,7 +1111,7 @@ export default function TeamToolsPage() {
                   className="w-full flex items-center gap-3 px-4 py-3 bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-800"
                 >
                   {expandedCategories.has('mcp') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-                  <Server className="w-4 h-4 text-gray-500" />
+                  <Server className="w-4 h-4 text-cyan-500" />
                   <span className="font-medium text-gray-900 dark:text-white">MCP Servers</span>
                   <span className="text-xs text-gray-500">
                     {searchQuery ? `${filteredEnabled} enabled, ${filteredDisabled} disabled` : `${enabledServers.length} enabled, ${disabledServers.length} disabled`}
@@ -1350,7 +1350,7 @@ export default function TeamToolsPage() {
                         )}
                         {toolCategory && (
                           <div className="mt-1">
-                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300">
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-cyan-50 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300">
                               {toolCategory}
                             </span>
                           </div>


### PR DESCRIPTION
## Summary
- Replace purple with cyan for MCP/A2A styling across admin and team pages
- Add orange gradient header icons to team pages for consistent branding:
  - Dashboard, Agents, Tools, Agent Runs, Prompts, Pending Changes, Templates
- Make MCP server icons cyan throughout the UI for visual consistency

## Changes
- **admin/config/page.tsx**: Purple → cyan for MCP/A2A elements
- **admin/templates/page.tsx**: Purple → cyan for MCP badges  
- **admin/defaults/page.tsx**: Cyan styling for MCP server icons
- **team/agents/page.tsx**: Cyan MCP styling + orange gradient header
- **team/tools/page.tsx**: Cyan MCP styling + orange gradient header
- **team/page.tsx**: Orange gradient header icon
- **team/agent-runs/page.tsx**: Orange gradient header icon
- **team/prompts/page.tsx**: Orange gradient header icon
- **team/pending-changes/page.tsx**: Orange gradient header icon
- **team/templates/page.tsx**: Orange gradient header icon

## Test plan
- [ ] Verify MCP icons appear cyan in admin config and team tools pages
- [ ] Verify header icons have orange gradient on all team pages
- [ ] Check dark mode styling is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)