### PR TITLE
fix: Add Helm ownership labels to knowledge-base ServiceAccount

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -152,6 +152,21 @@ jobs:
         with:
           version: 'v3.14.0'
 
+      - name: Adopt orphaned resources for Helm
+        run: |
+          # Fix ServiceAccounts that exist but weren't created by this Helm release
+          # This adds required Helm ownership labels so Helm can manage them
+          for sa in incidentfox-knowledge-base; do
+            if kubectl get serviceaccount "$sa" -n ${{ env.HELM_NAMESPACE }} &>/dev/null; then
+              echo "Patching ServiceAccount $sa with Helm ownership labels..."
+              kubectl label serviceaccount "$sa" -n ${{ env.HELM_NAMESPACE }} \
+                app.kubernetes.io/managed-by=Helm --overwrite
+              kubectl annotate serviceaccount "$sa" -n ${{ env.HELM_NAMESPACE }} \
+                meta.helm.sh/release-name=incidentfox \
+                meta.helm.sh/release-namespace=${{ env.HELM_NAMESPACE }} --overwrite
+            fi
+          done
+
       - name: Deploy with Helm
         working-directory: charts
         run: |

--- a/charts/incidentfox/templates/knowledge-base.yaml
+++ b/charts/incidentfox/templates/knowledge-base.yaml
@@ -5,10 +5,15 @@ kind: ServiceAccount
 metadata:
   name: incidentfox-knowledge-base
   namespace: {{ .Values.namespace }}
-  {{- if .Values.services.knowledgeBase.serviceAccountRoleArn }}
+  labels:
+    {{- include "incidentfox.labels" . | nindent 4 }}
+    app.kubernetes.io/component: knowledge-base
   annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+    {{- if .Values.services.knowledgeBase.serviceAccountRoleArn }}
     eks.amazonaws.com/role-arn: {{ .Values.services.knowledgeBase.serviceAccountRoleArn | quote }}
-  {{- end }}
+    {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Adds required Helm labels and annotations to the incidentfox-knowledge-base ServiceAccount and implements automatic adoption of orphaned resources in the deploy workflow. This resolves the 'cannot be imported into the current release' error during Helm upgrades.