### PR TITLE
fix: Add Helm labels to all knowledge-base resources

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -154,18 +154,29 @@ jobs:
 
       - name: Adopt orphaned resources for Helm
         run: |
-          # Fix ServiceAccounts that exist but weren't created by this Helm release
+          # Fix resources that exist but weren't created by this Helm release
           # This adds required Helm ownership labels so Helm can manage them
-          for sa in incidentfox-knowledge-base; do
-            if kubectl get serviceaccount "$sa" -n ${{ env.HELM_NAMESPACE }} &>/dev/null; then
-              echo "Patching ServiceAccount $sa with Helm ownership labels..."
-              kubectl label serviceaccount "$sa" -n ${{ env.HELM_NAMESPACE }} \
-                app.kubernetes.io/managed-by=Helm --overwrite
-              kubectl annotate serviceaccount "$sa" -n ${{ env.HELM_NAMESPACE }} \
+          RESOURCE_NAME="incidentfox-knowledge-base"
+          NS="${{ env.HELM_NAMESPACE }}"
+
+          # Helper function to patch a resource with Helm ownership metadata
+          patch_resource() {
+            local kind=$1
+            local name=$2
+            if kubectl get "$kind" "$name" -n "$NS" &>/dev/null; then
+              echo "Patching $kind/$name with Helm ownership labels..."
+              kubectl label "$kind" "$name" -n "$NS" app.kubernetes.io/managed-by=Helm --overwrite
+              kubectl annotate "$kind" "$name" -n "$NS" \
                 meta.helm.sh/release-name=incidentfox \
-                meta.helm.sh/release-namespace=${{ env.HELM_NAMESPACE }} --overwrite
+                meta.helm.sh/release-namespace="$NS" --overwrite
             fi
-          done
+          }
+
+          # Patch all knowledge-base resources
+          patch_resource serviceaccount "$RESOURCE_NAME"
+          patch_resource deployment "$RESOURCE_NAME"
+          patch_resource service "$RESOURCE_NAME"
+          patch_resource poddisruptionbudget "$RESOURCE_NAME"
 
       - name: Deploy with Helm
         working-directory: charts

--- a/charts/incidentfox/templates/knowledge-base.yaml
+++ b/charts/incidentfox/templates/knowledge-base.yaml
@@ -20,6 +20,9 @@ kind: Deployment
 metadata:
   name: incidentfox-knowledge-base
   namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "incidentfox.labels" . | nindent 4 }}
+    app.kubernetes.io/component: knowledge-base
 spec:
   replicas: {{ .Values.services.knowledgeBase.replicas }}
   selector:
@@ -121,6 +124,9 @@ kind: Service
 metadata:
   name: incidentfox-knowledge-base
   namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "incidentfox.labels" . | nindent 4 }}
+    app.kubernetes.io/component: knowledge-base
 spec:
   selector:
     app.kubernetes.io/name: incidentfox-knowledge-base
@@ -135,6 +141,9 @@ kind: PodDisruptionBudget
 metadata:
   name: incidentfox-knowledge-base
   namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "incidentfox.labels" . | nindent 4 }}
+    app.kubernetes.io/component: knowledge-base
 spec:
   minAvailable: {{ .Values.services.knowledgeBase.pdb.minAvailable }}
   selector:


### PR DESCRIPTION
Extends the previous fix to add Helm labels to Deployment, Service, and PDB (not just ServiceAccount). Also updates the GHA workflow to patch all 4 resource types before Helm upgrade.