### PR TITLE
Upgrade all agents to gpt-4o and fix log_analysis model bug

### DIFF
--- a/agent/src/ai_agent/agents/log_analysis_agent.py
+++ b/agent/src/ai_agent/agents/log_analysis_agent.py
@@ -371,13 +371,33 @@ def create_log_analysis_agent(
     if tool_guidance:
         system_prompt = system_prompt + "\n\n" + tool_guidance
 
+    # Get model settings from team config if available
+    model_name = config.openai.model
+    temperature = 0.2  # Lower temp for analytical tasks
+    max_tokens = config.openai.max_tokens
+
+    if team_cfg:
+        agent_config = team_cfg.get_agent_config("log_analysis")
+        if agent_config.model:
+            model_name = agent_config.model.name
+            temperature = agent_config.model.temperature
+            max_tokens = agent_config.model.max_tokens
+            logger.info(
+                "using_team_model_config",
+                agent="log_analysis",
+                model=model_name,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+
     return Agent[TaskContext](
         name="LogAnalysisAgent",
         instructions=system_prompt,
-        model=config.openai.model,
+        model=model_name,
         model_settings=ModelSettings(
-            temperature=0.2
-        ),  # Low temperature for analytical tasks
+            temperature=temperature,
+            max_tokens=max_tokens,
+        ),
         tools=tools,
         output_type=LogAnalysisResult,
     )

--- a/agent/src/ai_agent/core/config.py
+++ b/agent/src/ai_agent/core/config.py
@@ -32,7 +32,7 @@ class OpenAIConfig(BaseSettings):
     api_key: str = Field(..., description="OpenAI API key")
     # Default to a model compatible with structured outputs / JSON schema formatting
     # used by the Agents SDK.
-    model: str = Field(default="gpt-4o-mini", description="Default model to use")
+    model: str = Field(default="gpt-4o", description="Default model to use")
     temperature: float = Field(default=0.7, ge=0.0, le=2.0)
     max_tokens: int | None = Field(default=4000, gt=0)
     timeout: int = Field(default=60, description="Request timeout in seconds")

--- a/agent/src/ai_agent/core/config_service.py
+++ b/agent/src/ai_agent/core/config_service.py
@@ -50,7 +50,7 @@ class AgentPromptConfig(BaseModel):
 class AgentModelConfig(BaseModel):
     """Model configuration for an agent."""
 
-    name: str = "gpt-4o-mini"
+    name: str = "gpt-4o"
     temperature: float = 0.2
     max_tokens: int = 4000
 
@@ -83,7 +83,7 @@ class AgentConfig(BaseModel):
         """Get the model name."""
         if self.model:
             return self.model.name
-        return "gpt-4o-mini"
+        return "gpt-4o"
 
     def get_temperature(self) -> float:
         """Get the temperature."""

--- a/agent/src/ai_agent/core/partial_work.py
+++ b/agent/src/ai_agent/core/partial_work.py
@@ -100,7 +100,7 @@ def summarize_partial_work(
     exception,
     original_query: str,
     agent_name: str = "agent",
-    model: str = "gpt-4o-mini",
+    model: str = "gpt-4o",
 ) -> dict[str, Any]:
     """
     Use an LLM to summarize the partial work from a MaxTurnsExceeded exception.
@@ -109,7 +109,7 @@ def summarize_partial_work(
         exception: The MaxTurnsExceeded exception with run_data attached
         original_query: The original query/task given to the agent
         agent_name: Name of the agent for context
-        model: Which model to use for summarization (default: gpt-4o-mini for cost)
+        model: Which model to use for summarization (default: gpt-4o)
 
     Returns:
         Dict with:

--- a/local/config/init.sql
+++ b/local/config/init.sql
@@ -431,31 +431,31 @@ INSERT INTO node_configs (org_id, node_id, config_json, version, updated_by) VAL
         "agents": {
             "planner": {
                 "enabled": true,
-                "model": {"name": "gpt-4o-mini", "temperature": 0.2}
+                "model": {"name": "gpt-4o", "temperature": 0.2}
             },
             "investigation": {
                 "enabled": true,
-                "model": {"name": "gpt-4o-mini", "temperature": 0.2}
+                "model": {"name": "gpt-4o", "temperature": 0.2}
             },
             "k8s_agent": {
                 "enabled": true,
-                "model": {"name": "gpt-4o-mini", "temperature": 0.1}
+                "model": {"name": "gpt-4o", "temperature": 0.1}
             },
             "aws_agent": {
                 "enabled": true,
-                "model": {"name": "gpt-4o-mini", "temperature": 0.1}
+                "model": {"name": "gpt-4o", "temperature": 0.1}
             },
             "metrics_agent": {
                 "enabled": true,
-                "model": {"name": "gpt-4o-mini", "temperature": 0.1}
+                "model": {"name": "gpt-4o", "temperature": 0.1}
             },
             "coding_agent": {
                 "enabled": true,
-                "model": {"name": "gpt-4o-mini", "temperature": 0.2}
+                "model": {"name": "gpt-4o", "temperature": 0.2}
             },
             "ci_agent": {
                 "enabled": true,
-                "model": {"name": "gpt-4o-mini", "temperature": 0.1}
+                "model": {"name": "gpt-4o", "temperature": 0.1}
             }
         },
         "feature_flags": {

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -92,7 +92,7 @@ services:
     environment:
       # Required: OpenAI
       OPENAI_API_KEY: ${OPENAI_API_KEY}
-      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4o-mini}
+      OPENAI_MODEL: ${OPENAI_MODEL:-gpt-4o}
       # Only set OPENAI_BASE_URL if you're using a custom endpoint (LiteLLM, Azure, etc.)
       # Config service integration
       USE_CONFIG_SERVICE: "true"

--- a/local/incidentfox_cli/README.md
+++ b/local/incidentfox_cli/README.md
@@ -136,7 +136,7 @@ Add these to `.env` to enable additional tools:
 ```bash
 # Required
 OPENAI_API_KEY=sk-xxx
-OPENAI_MODEL=gpt-4o-mini
+OPENAI_MODEL=gpt-4o
 
 # Auto-generated (don't edit)
 TOKEN_PEPPER=xxx


### PR DESCRIPTION
Upgrades the entire Starship multi-agent system to use gpt-4o as the default LLM model instead of gpt-4o-mini. Also fixes a critical bug where the log_analysis agent was ignoring team config model overrides.

## Changes

- Default LLM model: gpt-4o-mini → gpt-4o (globally)
- Fixed log_analysis_agent to respect team config model settings
- Updated all seed data and configuration defaults

## Impact

All agents now use gpt-4o consistently, and team-level model overrides are properly respected across all agents.

🤖 Generated with Claude Code