### PR TITLE
Fix multi-tenant Slack output and entrance agent configuration

### DIFF
--- a/orchestrator/src/incidentfox_orchestrator/webhooks/router.py
+++ b/orchestrator/src/incidentfox_orchestrator/webhooks/router.py
@@ -730,7 +730,7 @@ async def _process_pagerduty_webhook(
 
         result = agent_api.run_agent(
             team_token=team_token,
-            agent_name="planner",
+            agent_name=entrance_agent_name,
             message=message,
             context=agent_context,
             timeout=int(
@@ -1111,7 +1111,7 @@ async def _process_incidentio_webhook(
 
         result = agent_api.run_agent(
             team_token=team_token,
-            agent_name="planner",
+            agent_name=entrance_agent_name,
             message=message,
             context=agent_context,
             timeout=int(


### PR DESCRIPTION
## Summary

Fixed two bugs in the incident webhook → agent run → Slack output flow:

1. **Issue #1**: Slack output destinations now include bot_token from team config
   - Enables multi-tenant scenarios where different teams use different Slack workspaces
   - Applied to all Slack output locations (Slack, GitHub, PagerDuty, Incident.io triggers)

2. **Issue #3**: PagerDuty and Incident.io webhooks now respect configured entrance_agent_name
   - Teams can customize their entrance agent via config instead of hardcoded "planner"

## Changes

- `output_resolver.py`: Extract bot_token from team integrations and include in all Slack destinations
- `router.py`: Use entrance_agent_name instead of hardcoded "planner" in PagerDuty and Incident.io handlers

🤖 Generated with Claude Code