### PR TITLE
fix: Fall back to SLACK_BOT_TOKEN env var for output destinations

### DIFF
--- a/orchestrator/src/incidentfox_orchestrator/output_resolver.py
+++ b/orchestrator/src/incidentfox_orchestrator/output_resolver.py
@@ -10,6 +10,7 @@ Determines where agent output should go based on:
 
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, List, Optional
 
 
@@ -50,9 +51,10 @@ def resolve_output_destinations(
 
     # Extract Slack bot_token from team integrations config
     # This enables multi-tenant scenarios where teams use different Slack workspaces
+    # Fall back to SLACK_BOT_TOKEN env var for single-tenant deployments
     slack_bot_token = (
         (team_config or {}).get("integrations", {}).get("slack", {}).get("bot_token")
-    )
+    ) or os.getenv("SLACK_BOT_TOKEN")
 
     # Legacy notifications config (for backward compatibility)
     notifications = (team_config or {}).get("notifications", {})


### PR DESCRIPTION
## Summary
- Fix Slack posting failing with "No Slack bot token available" when team config doesn't have `integrations.slack.bot_token`
- The orchestrator already has `SLACK_BOT_TOKEN` env var configured, but `output_resolver.py` wasn't using it as a fallback
- This enables single-tenant deployments to work without configuring the token in team config

## Root Cause
The `output_resolver.py` was only looking at `team_config.integrations.slack.bot_token` for the Slack bot token:
```python
slack_bot_token = (
    (team_config or {}).get("integrations", {}).get("slack", {}).get("bot_token")
)
```

When the team config didn't have this (common in single-tenant deployments), no token was passed to the agent, causing Slack posts to fail even though the orchestrator had `SLACK_BOT_TOKEN` configured.

## Fix
Added fallback to `os.getenv("SLACK_BOT_TOKEN")`:
```python
slack_bot_token = (
    (team_config or {}).get("integrations", {}).get("slack", {}).get("bot_token")
) or os.getenv("SLACK_BOT_TOKEN")
```

## Test plan
- [x] Verified with inline test that env var fallback works
- [x] Verified team config token still takes precedence
- [ ] Deploy and trigger incident.io webhook to verify Slack posting works

🤖 Generated with [Claude Code](https://claude.com/claude-code)