### PR TITLE
Fix stuck agent runs with synchronous completion and graceful shutdown

### DIFF
--- a/charts/incidentfox/templates/agent-runs-cleanup-cronjob.yaml
+++ b/charts/incidentfox/templates/agent-runs-cleanup-cronjob.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.services.agent.cleanup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: incidentfox-agent-runs-cleanup
+  namespace: {{ .Values.namespace }}
+spec:
+  schedule: {{ .Values.services.agent.cleanup.schedule | quote }}
+  concurrencyPolicy: Forbid  # Don't run if previous is still running
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      activeDeadlineSeconds: 120  # 2 minutes max
+      template:
+        metadata:
+          labels:
+            app: incidentfox-agent-runs-cleanup
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: cleanup
+              image: curlimages/curl:latest
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  echo "$(date -Iseconds) Starting stale agent runs cleanup"
+
+                  # Check stale count first (for logging)
+                  echo "$(date -Iseconds) Checking stale run count..."
+                  curl -sf \
+                    -H "X-Internal-Service: cleanup-cronjob" \
+                    "${CONFIG_SERVICE_URL}/api/v1/internal/agent-runs/stale-count?max_age_seconds=${MAX_AGE_SECONDS}" || true
+
+                  # Perform cleanup
+                  echo "$(date -Iseconds) Running cleanup..."
+                  RESULT=$(curl -sf \
+                    -X POST \
+                    -H "Content-Type: application/json" \
+                    -H "X-Internal-Service: cleanup-cronjob" \
+                    -d "{\"max_age_seconds\": ${MAX_AGE_SECONDS}}" \
+                    "${CONFIG_SERVICE_URL}/api/v1/internal/agent-runs/cleanup-stale")
+
+                  echo "$(date -Iseconds) Cleanup result: ${RESULT}"
+                  echo "$(date -Iseconds) Done"
+              env:
+                - name: CONFIG_SERVICE_URL
+                  value: {{ .Values.global.configService.url | quote }}
+                - name: MAX_AGE_SECONDS
+                  value: {{ .Values.services.agent.cleanup.maxAgeSeconds | quote }}
+              resources:
+                requests:
+                  cpu: "10m"
+                  memory: "32Mi"
+                limits:
+                  cpu: "100m"
+                  memory: "64Mi"
+{{- end }}

--- a/charts/incidentfox/templates/agent.yaml
+++ b/charts/incidentfox/templates/agent.yaml
@@ -33,6 +33,11 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.global.imagePullSecrets | indent 8 }}
       {{- end }}
+      # Allow enough time for graceful shutdown to mark in-flight runs as failed
+      # Default K8s is 30s, but agent runs can take 5+ minutes. We need time to:
+      # 1. Stop accepting new requests
+      # 2. Mark all in-flight runs as failed (HTTP calls to config service)
+      terminationGracePeriodSeconds: {{ .Values.services.agent.terminationGracePeriodSeconds | default 60 }}
       containers:
         - name: agent
           image: {{ required "services.agent.image is required" .Values.services.agent.image }}

--- a/charts/incidentfox/values.yaml
+++ b/charts/incidentfox/values.yaml
@@ -163,6 +163,9 @@ services:
     image: "incidentfox/agent:v1.0.0"
     replicas: 2
     servicePort: 8080
+    # Time to allow for graceful shutdown (marking in-flight runs as failed)
+    # Agent runs can take 5+ minutes, but shutdown only needs time to mark them
+    terminationGracePeriodSeconds: 60
     serviceAccount:
       create: true
       name: incidentfox-agent
@@ -207,6 +210,11 @@ services:
       enabled: false
       secretName: incidentfox-team-token
       secretKey: token
+    # Cleanup cronjob for stale agent runs (belt-and-suspenders for edge cases)
+    cleanup:
+      enabled: true
+      schedule: "*/5 * * * *"  # Every 5 minutes
+      maxAgeSeconds: 600       # Mark runs as timeout if running > 10 minutes
   orchestrator:
     enabled: true
     image: "incidentfox/orchestrator:v1.0.0"

--- a/scripts/cleanup_stale_agent_runs.sh
+++ b/scripts/cleanup_stale_agent_runs.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Cleanup Stale Agent Runs
+#
+# This script calls the config service to mark agent runs that have been stuck
+# in 'running' status as 'timeout'. This handles edge cases like:
+# - Process crash/OOM kill without graceful shutdown
+# - Network partition during completion recording
+# - Pod killed before shutdown handler completed
+#
+# Intended to be run as a Kubernetes CronJob every 5 minutes.
+#
+# Usage:
+#   ./cleanup_stale_agent_runs.sh
+#
+# Environment Variables:
+#   CONFIG_SERVICE_URL  - URL of the config service (required)
+#   MAX_AGE_SECONDS     - Mark runs older than this as timeout (default: 600 = 10 min)
+#   INTERNAL_SERVICE    - Service name for auth header (default: cleanup-job)
+#
+
+set -euo pipefail
+
+# Configuration
+CONFIG_SERVICE_URL="${CONFIG_SERVICE_URL:-http://incidentfox-config-service:8080}"
+MAX_AGE_SECONDS="${MAX_AGE_SECONDS:-600}"
+INTERNAL_SERVICE="${INTERNAL_SERVICE:-cleanup-job}"
+
+echo "$(date -Iseconds) Starting stale agent runs cleanup"
+echo "  Config Service: ${CONFIG_SERVICE_URL}"
+echo "  Max Age: ${MAX_AGE_SECONDS} seconds"
+
+# First, check how many stale runs there are (for logging/monitoring)
+STALE_COUNT_RESPONSE=$(curl -sf \
+  -H "X-Internal-Service: ${INTERNAL_SERVICE}" \
+  "${CONFIG_SERVICE_URL}/api/v1/internal/agent-runs/stale-count?max_age_seconds=${MAX_AGE_SECONDS}" \
+  || echo '{"error": "failed to get stale count"}')
+
+echo "$(date -Iseconds) Stale count check: ${STALE_COUNT_RESPONSE}"
+
+# Now perform the cleanup
+CLEANUP_RESPONSE=$(curl -sf \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-Internal-Service: ${INTERNAL_SERVICE}" \
+  -d "{\"max_age_seconds\": ${MAX_AGE_SECONDS}}" \
+  "${CONFIG_SERVICE_URL}/api/v1/internal/agent-runs/cleanup-stale" \
+  || echo '{"error": "cleanup request failed"}')
+
+echo "$(date -Iseconds) Cleanup result: ${CLEANUP_RESPONSE}"
+
+# Extract marked count for exit code determination
+MARKED_COUNT=$(echo "${CLEANUP_RESPONSE}" | grep -o '"marked_count":[0-9]*' | grep -o '[0-9]*' || echo "0")
+
+if [ "${MARKED_COUNT}" -gt 0 ]; then
+  echo "$(date -Iseconds) WARNING: Marked ${MARKED_COUNT} stale runs as timeout"
+else
+  echo "$(date -Iseconds) No stale runs found"
+fi
+
+echo "$(date -Iseconds) Cleanup complete"


### PR DESCRIPTION
## Summary

This PR fixes the issue of agent runs stuck in 'running' status indefinitely by implementing synchronous completion recording and proper graceful shutdown handling.

## Problem

Agent runs from days ago were stuck in 'running' status instead of being properly marked as completed, failed, or timed out. Root causes: fire-and-forget async tasks, no timeout cleanup mechanism, and insufficient pod termination grace period.

## Solution

A 4-layer defense-in-depth approach:
- **In-flight registry**: Thread-safe tracking for graceful shutdown access
- **Synchronous recording**: Await HTTP calls (5s timeout) instead of fire-and-forget
- **Graceful shutdown**: Mark in-flight runs as failed on pod termination
- **Cleanup cronjob**: Mark runs stuck >10 min as timeout (catches edge cases)

## Changes

- `agent_runner.py`: In-flight registry, sync recording, graceful shutdown handler
- `api_server.py`: Graceful shutdown hook on SIGTERM/SIGINT
- `internal.py`: New cleanup endpoints (/stale-count, /cleanup-stale)
- `repository.py`: Functions to detect and mark stale runs
- `agent.yaml`: Increased terminationGracePeriodSeconds to 60s
- `values.yaml`: Added cleanup configuration
- `agent-runs-cleanup-cronjob.yaml`: New K8s CronJob resource

🤖 Generated with Claude Code