### PR TITLE
Fix: Propagate ExecutionContext to sub-agent threads

### DIFF
--- a/agent/src/ai_agent/agents/planner.py
+++ b/agent/src/ai_agent/agents/planner.py
@@ -42,6 +42,7 @@ from pydantic import BaseModel, Field
 
 from ..core.config import get_config
 from ..core.config_utils import get_agent_sub_agents
+from ..core.execution_context import get_execution_context, propagate_context_to_thread
 from ..core.logging import get_logger
 from ..core.partial_work import summarize_partial_work
 from ..core.stream_events import (
@@ -105,8 +106,10 @@ def _run_agent_in_thread(
     """
     result_holder = {"result": None, "error": None, "partial": False}
 
-    # Capture stream_id from parent thread for event propagation
+    # Capture context from parent thread for propagation to child thread
+    # ContextVars don't automatically propagate to new threads
     parent_stream_id = get_current_stream_id()
+    parent_context = get_execution_context()
     agent_name = getattr(agent, "name", "unknown")
 
     def run_in_new_loop():
@@ -118,6 +121,10 @@ def _run_agent_in_thread(
             # Propagate stream_id to this thread
             if parent_stream_id:
                 set_current_stream_id(parent_stream_id)
+
+            # Propagate execution context to this thread
+            # This enables sub-agent tools to access integration configs (GitHub, etc.)
+            propagate_context_to_thread(parent_context)
 
             try:
                 if parent_stream_id and EventStreamRegistry.stream_exists(

--- a/agent/src/ai_agent/core/execution_context.py
+++ b/agent/src/ai_agent/core/execution_context.py
@@ -176,6 +176,35 @@ def clear_execution_context():
     _execution_context.set(None)
 
 
+def propagate_context_to_thread(parent_context: ExecutionContext | None) -> None:
+    """
+    Propagate execution context from parent thread to current thread.
+
+    Python's ContextVar does NOT automatically propagate to new threads.
+    Call this at the start of a new thread to restore the parent's context.
+
+    Usage in sub-agent threads:
+        # In parent thread:
+        parent_ctx = get_execution_context()
+
+        def run_in_new_thread():
+            # At start of new thread:
+            propagate_context_to_thread(parent_ctx)
+            # Now tools can access the context
+            ...
+
+    Args:
+        parent_context: ExecutionContext captured from parent thread
+    """
+    if parent_context:
+        _execution_context.set(parent_context)
+        logger.debug(
+            "execution_context_propagated_to_thread",
+            org_id=parent_context.org_id,
+            team_node_id=parent_context.team_node_id,
+        )
+
+
 def require_execution_context() -> ExecutionContext:
     """
     Get execution context, raising error if not set.


### PR DESCRIPTION
## Summary
Fixed GitHub token configuration not being available in sub-agents. Root cause: Python's ContextVar doesn't propagate to new threads, causing sub-agents (GitHub, K8s, AWS, etc.) to lose ExecutionContext and fail with "config_required" error.

## Solution
Added `propagate_context_to_thread()` helper to capture and restore ExecutionContext in sub-agent threads. Applied to all thread-spawning functions: `_run_agent_in_thread()` in investigation_agent, planner, agent_builder, and `make_sub_agent_tool()` in registry.

## Impact
GitHub tools (and all integration tools) now work correctly in sub-agent invocations triggered via incident.io webhooks.

## Testing
Validated with direct test on agent pod showing token now accessible in sub-agent threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)