### PR TITLE
fix: Handle non-JSON error responses in agent-runs API routes

### DIFF
--- a/web_ui/src/app/api/team/agent-runs/[runId]/route.ts
+++ b/web_ui/src/app/api/team/agent-runs/[runId]/route.ts
@@ -20,8 +20,18 @@ export async function GET(
         headers: { 'Authorization': `Bearer ${token}` },
       }
     );
-    
-    const data = await res.json();
+
+    const text = await res.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      // Backend returned non-JSON response (e.g., "Internal Server Error")
+      return NextResponse.json(
+        { error: text || `Request failed with status ${res.status}` },
+        { status: res.status >= 400 ? res.status : 500 }
+      );
+    }
     return NextResponse.json(data, { status: res.status });
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || 'Failed to fetch' }, { status: 500 });

--- a/web_ui/src/app/api/team/agent-runs/[runId]/trace/route.ts
+++ b/web_ui/src/app/api/team/agent-runs/[runId]/trace/route.ts
@@ -21,7 +21,17 @@ export async function GET(
       }
     );
 
-    const data = await res.json();
+    const text = await res.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      // Backend returned non-JSON response (e.g., "Internal Server Error")
+      return NextResponse.json(
+        { error: text || `Request failed with status ${res.status}` },
+        { status: res.status >= 400 ? res.status : 500 }
+      );
+    }
     return NextResponse.json(data, { status: res.status });
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || 'Failed to fetch trace' }, { status: 500 });

--- a/web_ui/src/app/api/team/agent-runs/route.ts
+++ b/web_ui/src/app/api/team/agent-runs/route.ts
@@ -17,8 +17,18 @@ export async function GET(request: NextRequest) {
         headers: { 'Authorization': `Bearer ${token}` },
       }
     );
-    
-    const data = await res.json();
+
+    const text = await res.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      // Backend returned non-JSON response (e.g., "Internal Server Error")
+      return NextResponse.json(
+        { error: text || `Request failed with status ${res.status}` },
+        { status: res.status >= 400 ? res.status : 500 }
+      );
+    }
     return NextResponse.json(data, { status: res.status });
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || 'Failed to fetch' }, { status: 500 });

--- a/web_ui/src/components/TraceViewer.tsx
+++ b/web_ui/src/components/TraceViewer.tsx
@@ -85,8 +85,8 @@ export function TraceViewer({ runId, correlationId }: TraceViewerProps) {
           const data = await res.json();
           setTrace(data);
         } else {
-          const errData = await res.json();
-          setError(errData.error || 'Failed to load trace');
+          const errData = await res.json().catch(() => ({}));
+          setError(errData.error || `Failed to load trace (${res.status})`);
         }
       } catch (e: any) {
         setError(e?.message || 'Failed to load trace');


### PR DESCRIPTION
## Summary
- Fix JSON parse error when backend returns plain text errors like "Internal Server Error"
- API routes now read response as text first, then safely parse with fallback
- TraceViewer component handles error responses gracefully

## Root Cause
The trace endpoint was returning `Internal Server Error` because the `agent_tool_calls` table was missing `agent_name` and `parent_agent` columns (migration not applied). The frontend tried to parse this as JSON and crashed.

## Changes
- `web_ui/src/app/api/team/agent-runs/route.ts` - Safe JSON parsing
- `web_ui/src/app/api/team/agent-runs/[runId]/route.ts` - Safe JSON parsing
- `web_ui/src/app/api/team/agent-runs/[runId]/trace/route.ts` - Safe JSON parsing
- `web_ui/src/components/TraceViewer.tsx` - Handle non-JSON error responses

## Test plan
- [x] Verified migration `20260122_agent_tracking` applied to production DB
- [ ] Deploy web-ui and verify agent runs page loads without JSON errors
- [ ] Test trace viewer with runs that have tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)