### PR TITLE
fix: Apply temperature fix to ALL agent creation paths

### DIFF
--- a/agent/src/ai_agent/agents/aws_agent.py
+++ b/agent/src/ai_agent/agents/aws_agent.py
@@ -1,6 +1,8 @@
 """AWS resource management and debugging agent."""
 
-from agents import Agent, ModelSettings
+from agents import Agent
+
+from ..core.agent_builder import create_model_settings
 from pydantic import BaseModel, Field
 
 from ..core.config import get_config
@@ -231,7 +233,8 @@ Be specific in recommendations:
         name="AWSAgent",
         instructions=system_prompt,
         model=model_name,
-        model_settings=ModelSettings(
+        model_settings=create_model_settings(
+            model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
         ),

--- a/agent/src/ai_agent/agents/ci_agent.py
+++ b/agent/src/ai_agent/agents/ci_agent.py
@@ -9,7 +9,9 @@ This agent specializes in:
 
 from typing import Any
 
-from agents import Agent, ModelSettings, function_tool
+from agents import Agent, function_tool
+
+from ..core.agent_builder import create_model_settings
 from pydantic import BaseModel, Field
 
 from ..core.config import get_config
@@ -313,7 +315,8 @@ def create_ci_agent(team_config: dict[str, Any] | None = None) -> Agent[TaskCont
         name="CIAgent",
         instructions=system_prompt,
         model=model_name,
-        model_settings=ModelSettings(
+        model_settings=create_model_settings(
+            model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
         ),

--- a/agent/src/ai_agent/agents/coding_agent.py
+++ b/agent/src/ai_agent/agents/coding_agent.py
@@ -1,6 +1,8 @@
 """Code analysis, bug fixing, and code generation agent."""
 
-from agents import Agent, ModelSettings, Tool, function_tool
+from agents import Agent, Tool, function_tool
+
+from ..core.agent_builder import create_model_settings
 from pydantic import BaseModel, Field
 
 from ..core.config import get_config
@@ -288,7 +290,8 @@ When providing fixes:
         name="CodingAgent",
         instructions=system_prompt,
         model=model_name,
-        model_settings=ModelSettings(
+        model_settings=create_model_settings(
+            model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
         ),

--- a/agent/src/ai_agent/agents/github_agent.py
+++ b/agent/src/ai_agent/agents/github_agent.py
@@ -1,6 +1,8 @@
 """GitHub repository operations agent."""
 
-from agents import Agent, ModelSettings, Tool, function_tool
+from agents import Agent, Tool, function_tool
+
+from ..core.agent_builder import create_model_settings
 from pydantic import BaseModel, Field
 
 from ..core.config import get_config
@@ -526,7 +528,8 @@ def create_github_agent(
         name="GitHubAgent",
         instructions=system_prompt,
         model=model_name,
-        model_settings=ModelSettings(
+        model_settings=create_model_settings(
+            model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
         ),

--- a/agent/src/ai_agent/agents/investigation_agent.py
+++ b/agent/src/ai_agent/agents/investigation_agent.py
@@ -29,7 +29,9 @@ import json
 import threading
 from typing import Any
 
-from agents import Agent, ModelSettings, Runner, function_tool
+from agents import Agent, Runner, function_tool
+
+from ..core.agent_builder import create_model_settings
 from agents.exceptions import MaxTurnsExceeded
 from agents.stream_events import RunItemStreamEvent
 from pydantic import BaseModel, Field
@@ -1019,7 +1021,8 @@ def create_investigation_agent(
         name="InvestigationAgent",
         instructions=system_prompt,
         model=model_name,
-        model_settings=ModelSettings(
+        model_settings=create_model_settings(
+            model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
         ),

--- a/agent/src/ai_agent/agents/k8s_agent.py
+++ b/agent/src/ai_agent/agents/k8s_agent.py
@@ -1,6 +1,8 @@
 """Kubernetes troubleshooting and operations agent."""
 
-from agents import Agent, ModelSettings, Tool, function_tool
+from agents import Agent, Tool, function_tool
+
+from ..core.agent_builder import create_model_settings
 from pydantic import BaseModel, Field
 
 from ..core.config import get_config
@@ -367,7 +369,8 @@ Always include the raw data so users can see the actual values."""
         name="K8sAgent",
         instructions=system_prompt,
         model=model_name,
-        model_settings=ModelSettings(
+        model_settings=create_model_settings(
+            model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
         ),

--- a/agent/src/ai_agent/agents/log_analysis_agent.py
+++ b/agent/src/ai_agent/agents/log_analysis_agent.py
@@ -1,6 +1,8 @@
 """Log Analysis Agent - Partition-first log investigation specialist."""
 
-from agents import Agent, ModelSettings, Tool, function_tool
+from agents import Agent, Tool, function_tool
+
+from ..core.agent_builder import create_model_settings
 from pydantic import BaseModel, Field
 
 from ..core.config import get_config
@@ -408,7 +410,8 @@ def create_log_analysis_agent(
         name="LogAnalysisAgent",
         instructions=system_prompt,
         model=model_name,
-        model_settings=ModelSettings(
+        model_settings=create_model_settings(
+            model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
         ),

--- a/agent/src/ai_agent/agents/metrics_agent.py
+++ b/agent/src/ai_agent/agents/metrics_agent.py
@@ -1,6 +1,8 @@
 """Metrics analysis and anomaly detection agent."""
 
-from agents import Agent, ModelSettings, Tool, function_tool
+from agents import Agent, Tool, function_tool
+
+from ..core.agent_builder import create_model_settings
 from pydantic import BaseModel, Field
 
 from ..core.config import get_config
@@ -427,7 +429,8 @@ When you find strong correlation, you've likely found the root cause path!"""
         name="MetricsAgent",
         instructions=system_prompt,
         model=model_name,
-        model_settings=ModelSettings(
+        model_settings=create_model_settings(
+            model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
         ),

--- a/agent/src/ai_agent/agents/planner.py
+++ b/agent/src/ai_agent/agents/planner.py
@@ -39,7 +39,9 @@ import json
 import threading
 from typing import Any
 
-from agents import Agent, ModelSettings, Runner, function_tool
+from agents import Agent, Runner, function_tool
+
+from ..core.agent_builder import create_model_settings
 from agents.exceptions import MaxTurnsExceeded
 from agents.stream_events import RunItemStreamEvent
 from pydantic import BaseModel, Field
@@ -762,7 +764,8 @@ def create_planner_agent(
         name="Planner",
         instructions=system_prompt,
         model=model_name,
-        model_settings=ModelSettings(
+        model_settings=create_model_settings(
+            model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
         ),

--- a/agent/src/ai_agent/agents/registry.py
+++ b/agent/src/ai_agent/agents/registry.py
@@ -82,8 +82,9 @@ def create_generic_agent_from_config(agent_name: str, team_config=None) -> Agent
     Returns:
         Configured Agent instance
     """
-    from agents import Agent, ModelSettings
+    from agents import Agent
 
+    from ..core.agent_builder import create_model_settings
     from ..tools.agent_tools import get_agent_tools
 
     config = get_config()
@@ -331,7 +332,8 @@ def create_generic_agent_from_config(agent_name: str, team_config=None) -> Agent
     agent = Agent[TaskContext](
         name=agent_config.name or agent_name,
         model=model_name,
-        model_settings=ModelSettings(
+        model_settings=create_model_settings(
+            model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
         ),

--- a/agent/src/ai_agent/agents/writeup_agent.py
+++ b/agent/src/ai_agent/agents/writeup_agent.py
@@ -1,6 +1,8 @@
 """Incident writeup and postmortem generation agent."""
 
-from agents import Agent, ModelSettings
+from agents import Agent
+
+from ..core.agent_builder import create_model_settings
 from pydantic import BaseModel, Field
 
 from ..core.config import get_config
@@ -331,7 +333,8 @@ def create_writeup_agent(
         name="WriteupAgent",
         instructions=system_prompt,
         model=model_name,
-        model_settings=ModelSettings(
+        model_settings=create_model_settings(
+            model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
         ),

--- a/agent/src/ai_agent/core/partial_work.py
+++ b/agent/src/ai_agent/core/partial_work.py
@@ -196,12 +196,21 @@ Respond in this exact JSON format:
 
 Only output the JSON, no other text."""
 
-        response = client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": prompt}],
-            max_tokens=500,
-            temperature=0,
-        )
+        # Reasoning models (o1, o3, o4, gpt-5) don't support temperature
+        reasoning_prefixes = ("o1", "o3", "o4", "gpt-5")
+        if model.startswith(reasoning_prefixes):
+            response = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=500,
+            )
+        else:
+            response = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=500,
+                temperature=0,
+            )
 
         # Parse the response
         try:

--- a/agent/src/ai_agent/tools/agent_tools.py
+++ b/agent/src/ai_agent/tools/agent_tools.py
@@ -195,12 +195,23 @@ def llm_call(prompt: str, system_prompt: str = "", purpose: str = "") -> str:
             messages.append({"role": "system", "content": system_prompt})
         messages.append({"role": "user", "content": prompt})
 
-        response = client.chat.completions.create(
-            model=os.getenv("OPENAI_MODEL", "gpt-4o"),
-            messages=messages,
-            temperature=0.7,
-            max_tokens=2000,
-        )
+        model = os.getenv("OPENAI_MODEL", "gpt-4o")
+
+        # Reasoning models (o1, o3, o4, gpt-5) don't support temperature
+        reasoning_prefixes = ("o1", "o3", "o4", "gpt-5")
+        if model.startswith(reasoning_prefixes):
+            response = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                max_tokens=2000,
+            )
+        else:
+            response = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                temperature=0.7,
+                max_tokens=2000,
+            )
         return json.dumps(
             {
                 "purpose": purpose,


### PR DESCRIPTION
## Summary
- Centralizes reasoning model detection with shared `create_model_settings()` helper in `agent_builder.py`
- Updates ALL 12+ agent files to use the helper instead of directly creating `ModelSettings`
- Fixes direct OpenAI client calls in `agent_tools.py` and `partial_work.py`

This ensures the temperature parameter is never sent to reasoning models (o1, o3, o4, gpt-5) regardless of which agent is invoked.

## Test plan
- [ ] Verify agent runs work with gpt-5 model
- [ ] Verify agent runs work with standard models (gpt-4o, gpt-4.1)
- [ ] Verify reasoning and verbosity settings are applied for reasoning models

🤖 Generated with [Claude Code](https://claude.com/claude-code)