### PR TITLE
fix: Extract and pass reasoning/verbosity from team config to agents

### DIFF
--- a/agent/src/ai_agent/agents/aws_agent.py
+++ b/agent/src/ai_agent/agents/aws_agent.py
@@ -214,6 +214,8 @@ Be specific in recommendations:
     model_name = config.openai.model
     temperature = 0.3
     max_tokens = config.openai.max_tokens
+    reasoning = None
+    verbosity = None
 
     if team_cfg:
         agent_config = team_cfg.get_agent_config("aws")
@@ -221,12 +223,16 @@ Be specific in recommendations:
             model_name = agent_config.model.name
             temperature = agent_config.model.temperature
             max_tokens = agent_config.model.max_tokens
+            reasoning = getattr(agent_config.model, "reasoning", None)
+            verbosity = getattr(agent_config.model, "verbosity", None)
             logger.info(
                 "using_team_model_config",
                 agent="aws",
                 model=model_name,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                reasoning=reasoning,
+                verbosity=verbosity,
             )
 
     return Agent[TaskContext](
@@ -237,6 +243,8 @@ Be specific in recommendations:
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            reasoning=reasoning,
+            verbosity=verbosity,
         ),
         tools=tools,
         output_type=AWSAnalysis,

--- a/agent/src/ai_agent/agents/ci_agent.py
+++ b/agent/src/ai_agent/agents/ci_agent.py
@@ -293,6 +293,8 @@ def create_ci_agent(team_config: dict[str, Any] | None = None) -> Agent[TaskCont
     model_name = config.openai.model
     temperature = 0.3  # Lower temp for precision
     max_tokens = config.openai.max_tokens
+    reasoning = None
+    verbosity = None
 
     if team_cfg:
         agent_config = team_cfg.get_agent_config("ci")
@@ -300,12 +302,16 @@ def create_ci_agent(team_config: dict[str, Any] | None = None) -> Agent[TaskCont
             model_name = agent_config.model.name
             temperature = agent_config.model.temperature
             max_tokens = agent_config.model.max_tokens
+            reasoning = getattr(agent_config.model, "reasoning", None)
+            verbosity = getattr(agent_config.model, "verbosity", None)
             logger.info(
                 "using_team_model_config",
                 agent="ci",
                 model=model_name,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                reasoning=reasoning,
+                verbosity=verbosity,
             )
 
     # Note: We don't use output_type because Dict fields aren't compatible with
@@ -319,6 +325,8 @@ def create_ci_agent(team_config: dict[str, Any] | None = None) -> Agent[TaskCont
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            reasoning=reasoning,
+            verbosity=verbosity,
         ),
         tools=tools,
     )

--- a/agent/src/ai_agent/agents/coding_agent.py
+++ b/agent/src/ai_agent/agents/coding_agent.py
@@ -271,6 +271,8 @@ When providing fixes:
     model_name = config.openai.model
     temperature = 0.4
     max_tokens = config.openai.max_tokens
+    reasoning = None
+    verbosity = None
 
     if team_cfg:
         agent_config = team_cfg.get_agent_config("coding")
@@ -278,12 +280,16 @@ When providing fixes:
             model_name = agent_config.model.name
             temperature = agent_config.model.temperature
             max_tokens = agent_config.model.max_tokens
+            reasoning = getattr(agent_config.model, "reasoning", None)
+            verbosity = getattr(agent_config.model, "verbosity", None)
             logger.info(
                 "using_team_model_config",
                 agent="coding",
                 model=model_name,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                reasoning=reasoning,
+                verbosity=verbosity,
             )
 
     return Agent[TaskContext](
@@ -294,6 +300,8 @@ When providing fixes:
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            reasoning=reasoning,
+            verbosity=verbosity,
         ),
         tools=tools,
         output_type=CodingAnalysis,

--- a/agent/src/ai_agent/agents/github_agent.py
+++ b/agent/src/ai_agent/agents/github_agent.py
@@ -488,6 +488,8 @@ def create_github_agent(
     model_name = config.openai.model
     temperature = 0.3
     max_tokens = config.openai.max_tokens
+    reasoning = None
+    verbosity = None
 
     if team_cfg:
         try:
@@ -510,16 +512,22 @@ def create_github_agent(
                         model_name = model_cfg.name
                         temperature = model_cfg.temperature
                         max_tokens = model_cfg.max_tokens
+                        reasoning = getattr(model_cfg, "reasoning", None)
+                        verbosity = getattr(model_cfg, "verbosity", None)
                     elif isinstance(model_cfg, dict):
                         model_name = model_cfg.get("name", model_name)
                         temperature = model_cfg.get("temperature", temperature)
                         max_tokens = model_cfg.get("max_tokens", max_tokens)
+                        reasoning = model_cfg.get("reasoning")
+                        verbosity = model_cfg.get("verbosity")
                     logger.info(
                         "using_team_model_config",
                         agent="github",
                         model=model_name,
                         temperature=temperature,
                         max_tokens=max_tokens,
+                        reasoning=reasoning,
+                        verbosity=verbosity,
                     )
         except Exception:
             pass
@@ -532,6 +540,8 @@ def create_github_agent(
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            reasoning=reasoning,
+            verbosity=verbosity,
         ),
         tools=tools,
         output_type=GitHubAnalysis,

--- a/agent/src/ai_agent/agents/investigation_agent.py
+++ b/agent/src/ai_agent/agents/investigation_agent.py
@@ -981,6 +981,8 @@ def create_investigation_agent(
     model_name = config.openai.model
     temperature = 0.2
     max_tokens = config.openai.max_tokens
+    reasoning = None
+    verbosity = None
 
     if team_cfg:
         try:
@@ -1003,16 +1005,22 @@ def create_investigation_agent(
                         model_name = model_cfg.name
                         temperature = model_cfg.temperature
                         max_tokens = model_cfg.max_tokens
+                        reasoning = getattr(model_cfg, "reasoning", None)
+                        verbosity = getattr(model_cfg, "verbosity", None)
                     elif isinstance(model_cfg, dict):
                         model_name = model_cfg.get("name", model_name)
                         temperature = model_cfg.get("temperature", temperature)
                         max_tokens = model_cfg.get("max_tokens", max_tokens)
+                        reasoning = model_cfg.get("reasoning")
+                        verbosity = model_cfg.get("verbosity")
                     logger.info(
                         "using_team_model_config",
                         agent="investigation",
                         model=model_name,
                         temperature=temperature,
                         max_tokens=max_tokens,
+                        reasoning=reasoning,
+                        verbosity=verbosity,
                     )
         except Exception:
             pass
@@ -1025,6 +1033,8 @@ def create_investigation_agent(
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            reasoning=reasoning,
+            verbosity=verbosity,
         ),
         tools=tools,
         output_type=InvestigationResult,

--- a/agent/src/ai_agent/agents/k8s_agent.py
+++ b/agent/src/ai_agent/agents/k8s_agent.py
@@ -350,6 +350,8 @@ Always include the raw data so users can see the actual values."""
     model_name = config.openai.model
     temperature = 0.3
     max_tokens = config.openai.max_tokens
+    reasoning = None
+    verbosity = None
 
     if team_cfg:
         agent_config = team_cfg.get_agent_config("k8s")
@@ -357,12 +359,16 @@ Always include the raw data so users can see the actual values."""
             model_name = agent_config.model.name
             temperature = agent_config.model.temperature
             max_tokens = agent_config.model.max_tokens
+            reasoning = getattr(agent_config.model, "reasoning", None)
+            verbosity = getattr(agent_config.model, "verbosity", None)
             logger.info(
                 "using_team_model_config",
                 agent="k8s",
                 model=model_name,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                reasoning=reasoning,
+                verbosity=verbosity,
             )
 
     return Agent[TaskContext](
@@ -373,6 +379,8 @@ Always include the raw data so users can see the actual values."""
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            reasoning=reasoning,
+            verbosity=verbosity,
         ),
         tools=tools,
         # Note: Removed output_type=K8sAnalysis to allow flexible responses

--- a/agent/src/ai_agent/agents/log_analysis_agent.py
+++ b/agent/src/ai_agent/agents/log_analysis_agent.py
@@ -391,6 +391,8 @@ def create_log_analysis_agent(
     model_name = config.openai.model
     temperature = 0.2  # Lower temp for analytical tasks
     max_tokens = config.openai.max_tokens
+    reasoning = None
+    verbosity = None
 
     if team_cfg:
         agent_config = team_cfg.get_agent_config("log_analysis")
@@ -398,12 +400,16 @@ def create_log_analysis_agent(
             model_name = agent_config.model.name
             temperature = agent_config.model.temperature
             max_tokens = agent_config.model.max_tokens
+            reasoning = getattr(agent_config.model, "reasoning", None)
+            verbosity = getattr(agent_config.model, "verbosity", None)
             logger.info(
                 "using_team_model_config",
                 agent="log_analysis",
                 model=model_name,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                reasoning=reasoning,
+                verbosity=verbosity,
             )
 
     return Agent[TaskContext](
@@ -414,6 +420,8 @@ def create_log_analysis_agent(
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            reasoning=reasoning,
+            verbosity=verbosity,
         ),
         tools=tools,
         output_type=LogAnalysisResult,

--- a/agent/src/ai_agent/agents/metrics_agent.py
+++ b/agent/src/ai_agent/agents/metrics_agent.py
@@ -410,6 +410,8 @@ When you find strong correlation, you've likely found the root cause path!"""
     model_name = config.openai.model
     temperature = 0.2  # Lower temp for analytical tasks
     max_tokens = config.openai.max_tokens
+    reasoning = None
+    verbosity = None
 
     if team_cfg:
         agent_config = team_cfg.get_agent_config("metrics")
@@ -417,12 +419,16 @@ When you find strong correlation, you've likely found the root cause path!"""
             model_name = agent_config.model.name
             temperature = agent_config.model.temperature
             max_tokens = agent_config.model.max_tokens
+            reasoning = getattr(agent_config.model, "reasoning", None)
+            verbosity = getattr(agent_config.model, "verbosity", None)
             logger.info(
                 "using_team_model_config",
                 agent="metrics",
                 model=model_name,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                reasoning=reasoning,
+                verbosity=verbosity,
             )
 
     return Agent[TaskContext](
@@ -433,6 +439,8 @@ When you find strong correlation, you've likely found the root cause path!"""
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            reasoning=reasoning,
+            verbosity=verbosity,
         ),
         tools=tools,
         output_type=MetricsAnalysis,

--- a/agent/src/ai_agent/agents/planner.py
+++ b/agent/src/ai_agent/agents/planner.py
@@ -723,6 +723,8 @@ def create_planner_agent(
     model_name = config.openai.model
     temperature = config.openai.temperature
     max_tokens = config.openai.max_tokens
+    reasoning = None
+    verbosity = None
 
     if team_cfg:
         try:
@@ -745,16 +747,22 @@ def create_planner_agent(
                         model_name = model_cfg.name
                         temperature = model_cfg.temperature
                         max_tokens = model_cfg.max_tokens
+                        reasoning = getattr(model_cfg, "reasoning", None)
+                        verbosity = getattr(model_cfg, "verbosity", None)
                     elif isinstance(model_cfg, dict):
                         model_name = model_cfg.get("name", model_name)
                         temperature = model_cfg.get("temperature", temperature)
                         max_tokens = model_cfg.get("max_tokens", max_tokens)
+                        reasoning = model_cfg.get("reasoning")
+                        verbosity = model_cfg.get("verbosity")
                     logger.info(
                         "using_team_model_config",
                         agent="planner",
                         model=model_name,
                         temperature=temperature,
                         max_tokens=max_tokens,
+                        reasoning=reasoning,
+                        verbosity=verbosity,
                     )
         except Exception:
             pass
@@ -768,6 +776,8 @@ def create_planner_agent(
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            reasoning=reasoning,
+            verbosity=verbosity,
         ),
         tools=all_tools,
         output_type=InvestigationSummary,

--- a/agent/src/ai_agent/agents/registry.py
+++ b/agent/src/ai_agent/agents/registry.py
@@ -327,6 +327,16 @@ def create_generic_agent_from_config(agent_name: str, team_config=None) -> Agent
         if agent_config.model
         else config.openai.max_tokens
     )
+    reasoning = (
+        getattr(agent_config.model, "reasoning", None)
+        if agent_config.model
+        else None
+    )
+    verbosity = (
+        getattr(agent_config.model, "verbosity", None)
+        if agent_config.model
+        else None
+    )
 
     # Create agent with config
     agent = Agent[TaskContext](
@@ -336,6 +346,8 @@ def create_generic_agent_from_config(agent_name: str, team_config=None) -> Agent
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            reasoning=reasoning,
+            verbosity=verbosity,
         ),
         instructions=system_prompt,
         tools=tools,

--- a/agent/src/ai_agent/agents/writeup_agent.py
+++ b/agent/src/ai_agent/agents/writeup_agent.py
@@ -293,6 +293,8 @@ def create_writeup_agent(
     model_name = config.openai.model
     temperature = 0.5  # Slightly higher for creative writing
     max_tokens = config.openai.max_tokens
+    reasoning = None
+    verbosity = None
 
     if team_cfg:
         try:
@@ -315,16 +317,22 @@ def create_writeup_agent(
                         model_name = model_cfg.name
                         temperature = model_cfg.temperature
                         max_tokens = model_cfg.max_tokens
+                        reasoning = getattr(model_cfg, "reasoning", None)
+                        verbosity = getattr(model_cfg, "verbosity", None)
                     elif isinstance(model_cfg, dict):
                         model_name = model_cfg.get("name", model_name)
                         temperature = model_cfg.get("temperature", temperature)
                         max_tokens = model_cfg.get("max_tokens", max_tokens)
+                        reasoning = model_cfg.get("reasoning")
+                        verbosity = model_cfg.get("verbosity")
                     logger.info(
                         "using_team_model_config",
                         agent="writeup",
                         model=model_name,
                         temperature=temperature,
                         max_tokens=max_tokens,
+                        reasoning=reasoning,
+                        verbosity=verbosity,
                     )
         except Exception:
             pass
@@ -337,6 +345,8 @@ def create_writeup_agent(
             model_name=model_name,
             temperature=temperature,
             max_tokens=max_tokens,
+            reasoning=reasoning,
+            verbosity=verbosity,
         ),
         tools=tools,
         output_type=PostmortemDocument,


### PR DESCRIPTION
## Summary
- Root cause: All 11 agent factory functions were only extracting `name`, `temperature`, and `max_tokens` from model config
- The `reasoning` and `verbosity` fields were never extracted or passed to `create_model_settings()`, causing them to always default to `"medium"`
- This fix updates all agent files to extract and pass these fields properly

## Changes
Each agent file now:
1. Initializes `reasoning = None` and `verbosity = None`
2. Extracts `reasoning`/`verbosity` from model config (both object attribute and dict formats)
3. Passes `reasoning`/`verbosity` to `create_model_settings()`
4. Logs `reasoning`/`verbosity` in the team model config log message

## Files updated
- planner.py
- investigation_agent.py
- coding_agent.py
- writeup_agent.py
- k8s_agent.py
- aws_agent.py
- github_agent.py
- ci_agent.py
- log_analysis_agent.py
- metrics_agent.py
- registry.py

## Test plan
- [ ] Set reasoning to "high" in web UI for an agent
- [ ] Run agent and verify traces show reasoning effort = "high" (not "medium")
- [ ] Verify verbosity setting is also passed through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)