### PR TITLE
Fix Coralogix log extraction and query syntax

### DIFF
--- a/local/claude_code_pack/mcp-servers/incidentfox/src/incidentfox_mcp/tools/log_analysis.py
+++ b/local/claude_code_pack/mcp-servers/incidentfox/src/incidentfox_mcp/tools/log_analysis.py
@@ -600,7 +600,9 @@ class CoralogixBackend(LogBackend):
         top_patterns = []
         for r in pattern_results:
             # GroupBy result may use different field names - try multiple
-            body = r.get("logRecord.body") or r.get("body") or self._extract_body(r) or ""
+            body = (
+                r.get("logRecord.body") or r.get("body") or self._extract_body(r) or ""
+            )
             top_patterns.append({"pattern": str(body)[:100], "count": r.get("cnt", 0)})
 
         return {


### PR DESCRIPTION
## Problem
The CoralogixBackend had critical bugs preventing proper log retrieval:
- Empty message bodies due to wrong field path
- Invalid DataPrime query syntax for severity filtering
- Pattern search using unsupported "contains" operator

## Solution
- Added helper methods to properly extract log bodies and trace IDs from nested userData structure
- Fixed severity filter to use numeric comparisons (>= 5 for ERROR/CRITICAL levels)
- Updated pattern search to use DataPrime's ~ operator for substring matching
- Added query escaping for special characters in patterns

## Impact
Payment service and other logs now correctly display message content and metadata, fixing false negatives in error detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)