### PR TITLE
fix: Align agent config keys with config service schema

### DIFF
--- a/agent/src/ai_agent/agents/aws_agent.py
+++ b/agent/src/ai_agent/agents/aws_agent.py
@@ -65,7 +65,7 @@ def create_aws_agent(
     # Check if team has custom prompt
     custom_prompt = None
     if team_cfg:
-        agent_config = team_cfg.get_agent_config("aws_agent")
+        agent_config = team_cfg.get_agent_config("aws")
         if agent_config.prompt:
             custom_prompt = agent_config.get_system_prompt()
             if custom_prompt:

--- a/agent/src/ai_agent/agents/ci_agent.py
+++ b/agent/src/ai_agent/agents/ci_agent.py
@@ -269,7 +269,7 @@ def create_ci_agent(team_config: dict[str, Any] | None = None) -> Agent[TaskCont
     # Check if team has custom prompt
     custom_prompt = None
     if team_cfg:
-        agent_config = team_cfg.get_agent_config("ci_agent")
+        agent_config = team_cfg.get_agent_config("ci")
         if agent_config and agent_config.prompt:
             custom_prompt = agent_config.get_system_prompt()
             if custom_prompt:

--- a/agent/src/ai_agent/agents/coding_agent.py
+++ b/agent/src/ai_agent/agents/coding_agent.py
@@ -142,7 +142,7 @@ def create_coding_agent(
     # Check if team has custom prompt
     custom_prompt = None
     if team_cfg:
-        agent_config = team_cfg.get_agent_config("coding_agent")
+        agent_config = team_cfg.get_agent_config("coding")
         if agent_config.prompt:
             custom_prompt = agent_config.get_system_prompt()
             if custom_prompt:

--- a/agent/src/ai_agent/agents/github_agent.py
+++ b/agent/src/ai_agent/agents/github_agent.py
@@ -429,12 +429,10 @@ def create_github_agent(
         try:
             agent_config = None
             if hasattr(team_cfg, "get_agent_config"):
-                agent_config = team_cfg.get_agent_config("github_agent")
-                if not agent_config:
-                    agent_config = team_cfg.get_agent_config("github")
+                agent_config = team_cfg.get_agent_config("github")
             elif isinstance(team_cfg, dict):
                 agents = team_cfg.get("agents", {})
-                agent_config = agents.get("github_agent") or agents.get("github")
+                agent_config = agents.get("github")
 
             if agent_config:
                 if hasattr(agent_config, "get_system_prompt"):

--- a/agent/src/ai_agent/agents/investigation_agent.py
+++ b/agent/src/ai_agent/agents/investigation_agent.py
@@ -937,14 +937,10 @@ def create_investigation_agent(
         try:
             agent_cfg = None
             if hasattr(team_cfg, "get_agent_config"):
-                agent_cfg = team_cfg.get_agent_config("investigation_agent")
-                if not agent_cfg:
-                    agent_cfg = team_cfg.get_agent_config("investigation")
+                agent_cfg = team_cfg.get_agent_config("investigation")
             elif isinstance(team_cfg, dict):
                 agents = team_cfg.get("agents", {})
-                agent_cfg = agents.get("investigation_agent") or agents.get(
-                    "investigation"
-                )
+                agent_cfg = agents.get("investigation")
 
             if agent_cfg:
                 if hasattr(agent_cfg, "get_system_prompt"):

--- a/agent/src/ai_agent/agents/k8s_agent.py
+++ b/agent/src/ai_agent/agents/k8s_agent.py
@@ -135,7 +135,7 @@ def create_k8s_agent(
     # Check if team has custom prompt
     custom_prompt = None
     if team_cfg:
-        agent_config = team_cfg.get_agent_config("k8s_agent")
+        agent_config = team_cfg.get_agent_config("k8s")
         if agent_config.prompt:
             custom_prompt = agent_config.get_system_prompt()
             if custom_prompt:

--- a/agent/src/ai_agent/agents/log_analysis_agent.py
+++ b/agent/src/ai_agent/agents/log_analysis_agent.py
@@ -347,7 +347,7 @@ def create_log_analysis_agent(
     custom_prompt = None
     if team_cfg:
         try:
-            agent_config = team_cfg.get_agent_config("log_analysis_agent")
+            agent_config = team_cfg.get_agent_config("log_analysis")
             if agent_config and agent_config.prompt:
                 custom_prompt = agent_config.prompt
                 logger.info(

--- a/agent/src/ai_agent/agents/metrics_agent.py
+++ b/agent/src/ai_agent/agents/metrics_agent.py
@@ -219,7 +219,7 @@ def create_metrics_agent(
     # Check if team has custom prompt
     custom_prompt = None
     if team_cfg:
-        agent_config = team_cfg.get_agent_config("metrics_agent")
+        agent_config = team_cfg.get_agent_config("metrics")
         if agent_config.prompt:
             custom_prompt = agent_config.get_system_prompt()
             if custom_prompt:

--- a/agent/src/ai_agent/agents/writeup_agent.py
+++ b/agent/src/ai_agent/agents/writeup_agent.py
@@ -232,12 +232,10 @@ def create_writeup_agent(
         try:
             agent_config = None
             if hasattr(team_cfg, "get_agent_config"):
-                agent_config = team_cfg.get_agent_config("writeup_agent")
-                if not agent_config:
-                    agent_config = team_cfg.get_agent_config("writeup")
+                agent_config = team_cfg.get_agent_config("writeup")
             elif isinstance(team_cfg, dict):
                 agents = team_cfg.get("agents", {})
-                agent_config = agents.get("writeup_agent") or agents.get("writeup")
+                agent_config = agents.get("writeup")
 
             if agent_config:
                 if hasattr(agent_config, "get_system_prompt"):


### PR DESCRIPTION
## Summary

Agents were looking up custom prompts using incorrect config keys (e.g., "k8s_agent" instead of "k8s"), causing them to ignore team configuration and fall back to hardcoded defaults.

## Changes

Fixed prompt lookup keys across all 9 agents to match the config service schema:
- k8s_agent → k8s
- log_analysis_agent → log_analysis
- aws_agent → aws
- metrics_agent → metrics
- coding_agent → coding
- ci_agent → ci
- github_agent → github
- investigation_agent → investigation
- writeup_agent → writeup

Also simplified fallback patterns to avoid unnecessary "_agent" suffixed lookups.

## Impact

Teams can now customize agent system prompts via the config service and have them actually used instead of being silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)