### PR TITLE
fix: Use get_system_prompt() to extract string from AgentPromptConfig

### DIFF
--- a/agent/src/ai_agent/agents/github_agent.py
+++ b/agent/src/ai_agent/agents/github_agent.py
@@ -437,8 +437,6 @@ def create_github_agent(
             if agent_config:
                 if hasattr(agent_config, "get_system_prompt"):
                     custom_prompt = agent_config.get_system_prompt()
-                elif hasattr(agent_config, "prompt") and agent_config.prompt:
-                    custom_prompt = agent_config.prompt
                 elif isinstance(agent_config, dict) and agent_config.get("prompt"):
                     prompt_cfg = agent_config["prompt"]
                     if isinstance(prompt_cfg, str):

--- a/agent/src/ai_agent/agents/log_analysis_agent.py
+++ b/agent/src/ai_agent/agents/log_analysis_agent.py
@@ -349,10 +349,12 @@ def create_log_analysis_agent(
         try:
             agent_config = team_cfg.get_agent_config("log_analysis")
             if agent_config and agent_config.prompt:
-                custom_prompt = agent_config.prompt
-                logger.info(
-                    "using_custom_log_analysis_prompt", prompt_length=len(custom_prompt)
-                )
+                custom_prompt = agent_config.get_system_prompt()
+                if custom_prompt:
+                    logger.info(
+                        "using_custom_log_analysis_prompt",
+                        prompt_length=len(custom_prompt),
+                    )
         except Exception:
             pass
 

--- a/agent/src/ai_agent/agents/writeup_agent.py
+++ b/agent/src/ai_agent/agents/writeup_agent.py
@@ -240,8 +240,6 @@ def create_writeup_agent(
             if agent_config:
                 if hasattr(agent_config, "get_system_prompt"):
                     custom_prompt = agent_config.get_system_prompt()
-                elif hasattr(agent_config, "prompt") and agent_config.prompt:
-                    custom_prompt = agent_config.prompt
                 elif isinstance(agent_config, dict) and agent_config.get("prompt"):
                     prompt_cfg = agent_config["prompt"]
                     if isinstance(prompt_cfg, str):


### PR DESCRIPTION
## Summary
Agents were directly accessing `agent_config.prompt` which can return an `AgentPromptConfig` object instead of a string, causing `TypeError` in prompt joining. Fixed by using `get_system_prompt()` method which properly handles both formats.

## Root Cause
PR #127 fixed config key lookups (e.g., `log_analysis_agent` → `log_analysis`), which exposed this bug. Previously, agents would get `AgentConfig()` with `prompt=None` (wrong key) and fall back to hardcoded prompts. Now they correctly load team config with structured prompts, but the code wasn't prepared to handle `AgentPromptConfig` objects.

## Fix
- **log_analysis_agent.py**: Changed to use `get_system_prompt()` 
- **github_agent.py**: Removed buggy fallback accessing `.prompt` directly
- **writeup_agent.py**: Removed buggy fallback accessing `.prompt` directly

## Impact
This fixes incident.io webhooks completely failing with 500 error (no Slack messages posted at all).

🦊 Generated with [Claude Code](https://claude.com/claude-code)