### PR TITLE
fix: Use DataPrime ~ operator for Coralogix substring matching

### DIFF
--- a/agent/src/ai_agent/tools/coralogix_tools.py
+++ b/agent/src/ai_agent/tools/coralogix_tools.py
@@ -129,7 +129,7 @@ def search_coralogix_logs(
     Example queries:
     - List all services: "source logs | groupby $l.subsystemname aggregate count() as cnt | orderby cnt desc | limit 20"
     - Get service errors: "source logs | filter $l.subsystemname == '<service>' | filter $m.severity == ERROR || $m.severity == CRITICAL | limit 50"
-    - Search for text: "source logs | filter $d.logRecord.body contains 'error' | limit 20"
+    - Search for text: "source logs | filter $d.logRecord.body:string ~ 'error' | limit 20"
 
     Args:
         query: DataPrime query string. ALWAYS start with "source logs |"

--- a/agent/src/ai_agent/tools/log_analysis_tools.py
+++ b/agent/src/ai_agent/tools/log_analysis_tools.py
@@ -711,9 +711,12 @@ class CoralogixBackend(LogBackend):
         **kwargs,
     ) -> dict[str, Any]:
         """Search Coralogix by pattern."""
-        query = f"source logs | filter $d.logRecord.body contains '{pattern}' | limit {max_results}"
+        # Escape single quotes in pattern for DataPrime query
+        escaped_pattern = pattern.replace("'", "\\'")
+        # Use ~ operator for substring matching in DataPrime (contains equivalent)
+        query = f"source logs | filter $d.logRecord.body:string ~ '{escaped_pattern}' | limit {max_results}"
         if service:
-            query = f"source logs | filter $l.subsystemname == '{service}' | filter $d.logRecord.body contains '{pattern}' | limit {max_results}"
+            query = f"source logs | filter $l.subsystemname == '{service}' | filter $d.logRecord.body:string ~ '{escaped_pattern}' | limit {max_results}"
 
         results = self._query(query, start_time, end_time, limit=max_results)
 


### PR DESCRIPTION
## Summary
Fixed Coralogix query syntax error in log_analysis_tools.py. The DataPrime query language uses the `~` operator for substring matching, not `contains`. Also properly escapes single quotes and adds the `:string` type hint.

## Test
Tested with Coralogix API key against payment service logs. Query now correctly returns 50 matches for "token" pattern in 4h time range.