### PR TITLE
feat: Add lazy S3 loading for knowledge trees with improved UX

### DIFF
--- a/knowledge_base/requirements.txt
+++ b/knowledge_base/requirements.txt
@@ -58,3 +58,6 @@ tqdm>=4.66.0
 fastapi>=0.110.0
 uvicorn>=0.27.0
 httpx>=0.26.0
+
+# S3 for lazy tree loading (dynamic multi-tenant)
+boto3>=1.34.0

--- a/web_ui/src/app/api/team/knowledge/tree/ask/route.ts
+++ b/web_ui/src/app/api/team/knowledge/tree/ask/route.ts
@@ -2,21 +2,28 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const RAPTOR_API_URL = process.env.RAPTOR_API_URL || 'http://localhost:8000';
 
+// Extended timeout - Q&A can take longer due to LLM inference + potential tree loading
+export const maxDuration = 300;
+
 /**
  * POST /api/team/knowledge/tree/ask
  * Ask a question and get an answer from the knowledge base with citations
  */
 export async function POST(request: NextRequest) {
   const token = request.cookies.get('incidentfox_session_token')?.value;
-  
+
   if (!token) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
   }
 
+  // Extended timeout for the upstream request
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 300000);
+
   try {
     const body = await request.json();
     const { question, tree = 'mega_ultra_v2', top_k = 5 } = body;
-    
+
     if (!question) {
       return NextResponse.json({ error: 'Question is required' }, { status: 400 });
     }
@@ -28,16 +35,25 @@ export async function POST(request: NextRequest) {
         'Accept': 'application/json',
       },
       body: JSON.stringify({ question, tree, top_k }),
+      signal: controller.signal,
     });
-    
+    clearTimeout(timeoutId);
+
     if (!res.ok) {
       const err = await res.text();
       return NextResponse.json({ error: err }, { status: res.status });
     }
-    
+
     const data = await res.json();
     return NextResponse.json(data);
   } catch (e: any) {
+    clearTimeout(timeoutId);
+    if (e.name === 'AbortError') {
+      return NextResponse.json(
+        { error: 'Request timed out. Tree may still be loading - please try again.' },
+        { status: 504 }
+      );
+    }
     console.error('RAPTOR API error:', e);
     return NextResponse.json({ error: e?.message || 'Failed to answer question' }, { status: 500 });
   }

--- a/web_ui/src/app/api/team/knowledge/tree/cache/route.ts
+++ b/web_ui/src/app/api/team/knowledge/tree/cache/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const RAPTOR_API_URL = process.env.RAPTOR_API_URL || 'http://localhost:8000';
+
+/**
+ * GET /api/team/knowledge/tree/cache
+ * Returns cache statistics from RAPTOR API
+ *
+ * Used by the UI to check if a tree is cached before attempting to load it.
+ * If a tree is not cached, the UI can show an appropriate message about
+ * first-time loading taking longer.
+ */
+export async function GET(request: NextRequest) {
+  const token = request.cookies.get('incidentfox_session_token')?.value;
+
+  if (!token) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  try {
+    const res = await fetch(
+      `${RAPTOR_API_URL}/api/v1/cache/stats`,
+      {
+        headers: { 'Accept': 'application/json' },
+        cache: 'no-store',
+      }
+    );
+
+    if (!res.ok) {
+      const err = await res.text();
+      return NextResponse.json({ error: err }, { status: res.status });
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (e: any) {
+    console.error('RAPTOR API cache stats error:', e);
+    return NextResponse.json({ error: e?.message || 'Failed to fetch cache stats' }, { status: 500 });
+  }
+}

--- a/web_ui/src/app/api/team/knowledge/tree/route.ts
+++ b/web_ui/src/app/api/team/knowledge/tree/route.ts
@@ -2,13 +2,18 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const RAPTOR_API_URL = process.env.RAPTOR_API_URL || 'http://localhost:8000';
 
+// Extended timeout for first-time tree loads that may require S3 download
+export const maxDuration = 300; // 5 minutes
+
 /**
  * GET /api/team/knowledge/tree
  * Returns tree structure for visualization (top layers)
+ *
+ * Note: This endpoint may trigger lazy loading of trees from S3 on first access.
  */
 export async function GET(request: NextRequest) {
   const token = request.cookies.get('incidentfox_session_token')?.value;
-  
+
   if (!token) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
   }
@@ -18,23 +23,36 @@ export async function GET(request: NextRequest) {
   const maxLayers = searchParams.get('maxLayers') || '3';
   const maxNodesPerLayer = searchParams.get('maxNodesPerLayer') || '200';
 
+  // Extended timeout for the upstream request
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 300000);
+
   try {
     const res = await fetch(
       `${RAPTOR_API_URL}/api/v1/tree/structure?tree=${encodeURIComponent(tree)}&max_layers=${maxLayers}&max_nodes_per_layer=${maxNodesPerLayer}`,
       {
         headers: { 'Accept': 'application/json' },
         cache: 'no-store',
+        signal: controller.signal,
       }
     );
-    
+    clearTimeout(timeoutId);
+
     if (!res.ok) {
       const err = await res.text();
       return NextResponse.json({ error: err }, { status: res.status });
     }
-    
+
     const data = await res.json();
     return NextResponse.json(data);
   } catch (e: any) {
+    clearTimeout(timeoutId);
+    if (e.name === 'AbortError') {
+      return NextResponse.json(
+        { error: 'Request timed out. Tree may still be downloading - please try again.' },
+        { status: 504 }
+      );
+    }
     console.error('RAPTOR API error:', e);
     return NextResponse.json({ error: e?.message || 'Failed to fetch tree structure' }, { status: 500 });
   }

--- a/web_ui/src/app/api/team/knowledge/tree/search/route.ts
+++ b/web_ui/src/app/api/team/knowledge/tree/search/route.ts
@@ -2,21 +2,28 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const RAPTOR_API_URL = process.env.RAPTOR_API_URL || 'http://localhost:8000';
 
+// Extended timeout for first-time tree loads
+export const maxDuration = 300;
+
 /**
  * POST /api/team/knowledge/tree/search
  * Search for nodes in the tree (for highlighting in visualization)
  */
 export async function POST(request: NextRequest) {
   const token = request.cookies.get('incidentfox_session_token')?.value;
-  
+
   if (!token) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
   }
 
+  // Extended timeout for the upstream request
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 300000);
+
   try {
     const body = await request.json();
     const { query, tree = 'mega_ultra_v2', limit = 50 } = body;
-    
+
     if (!query) {
       return NextResponse.json({ error: 'Query is required' }, { status: 400 });
     }
@@ -28,16 +35,25 @@ export async function POST(request: NextRequest) {
         'Accept': 'application/json',
       },
       body: JSON.stringify({ query, tree, limit }),
+      signal: controller.signal,
     });
-    
+    clearTimeout(timeoutId);
+
     if (!res.ok) {
       const err = await res.text();
       return NextResponse.json({ error: err }, { status: res.status });
     }
-    
+
     const data = await res.json();
     return NextResponse.json(data);
   } catch (e: any) {
+    clearTimeout(timeoutId);
+    if (e.name === 'AbortError') {
+      return NextResponse.json(
+        { error: 'Search timed out. Tree may still be loading - please try again.' },
+        { status: 504 }
+      );
+    }
     console.error('RAPTOR API error:', e);
     return NextResponse.json({ error: e?.message || 'Search failed' }, { status: 500 });
   }

--- a/web_ui/src/app/api/team/knowledge/tree/stats/route.ts
+++ b/web_ui/src/app/api/team/knowledge/tree/stats/route.ts
@@ -2,13 +2,20 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const RAPTOR_API_URL = process.env.RAPTOR_API_URL || 'http://localhost:8000';
 
+// Extended timeout for first-time tree loads that may require S3 download
+// This can take 1-2 minutes for large trees (~1.5GB)
+export const maxDuration = 300; // 5 minutes
+
 /**
  * GET /api/team/knowledge/tree/stats
  * Returns tree statistics (node counts, layers, etc.)
+ *
+ * Note: This endpoint may trigger lazy loading of trees from S3 on first access.
+ * The extended timeout (maxDuration) accommodates large tree downloads.
  */
 export async function GET(request: NextRequest) {
   const token = request.cookies.get('incidentfox_session_token')?.value;
-  
+
   if (!token) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
   }
@@ -16,23 +23,37 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const tree = searchParams.get('tree') || 'mega_ultra_v2';
 
+  // Extended timeout for the upstream request (5 minutes for S3 downloads)
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 300000);
+
   try {
     const res = await fetch(
       `${RAPTOR_API_URL}/api/v1/tree/stats?tree=${encodeURIComponent(tree)}`,
       {
         headers: { 'Accept': 'application/json' },
         cache: 'no-store',
+        signal: controller.signal,
       }
     );
-    
+    clearTimeout(timeoutId);
+
     if (!res.ok) {
       const err = await res.text();
       return NextResponse.json({ error: err }, { status: res.status });
     }
-    
+
     const data = await res.json();
     return NextResponse.json(data);
   } catch (e: any) {
+    clearTimeout(timeoutId);
+    if (e.name === 'AbortError') {
+      console.error('RAPTOR API timeout - tree may be downloading from S3');
+      return NextResponse.json(
+        { error: 'Request timed out. Tree may still be downloading - please try again in a few minutes.' },
+        { status: 504 }
+      );
+    }
     console.error('RAPTOR API error:', e);
     return NextResponse.json({ error: e?.message || 'Failed to fetch tree stats' }, { status: 500 });
   }


### PR DESCRIPTION
## Summary

- **Lazy S3 Loading**: Trees are now downloaded on-demand from S3 when first requested, replacing static Helm configuration
- **LRU Cache Management**: Implements intelligent caching with configurable limits (5 trees, 16GB default)
- **Improved Loading UX**: Shows informative messages for first-time tree downloads ("This may take 1-2 minutes")
- **Extended Timeouts**: All tree API routes now support 5-minute timeouts for S3 downloads

## Key Changes

### Backend (knowledge_base/api_server.py)
- S3 lazy loading with thread-safe download locks
- LRU eviction based on tree count and memory limits
- New `/api/v1/cache/stats` endpoint for monitoring

### Config Service
- New `/api/v1/internal/active-trees` endpoint for querying all configured trees

### Web UI
- Pre-flight cache check before loading
- Enhanced loading UI with progress messaging
- Extended timeouts (5 min) on all tree routes

## Test plan

- [ ] Verify tree loads correctly when cached locally
- [ ] Test first-time load from S3 shows appropriate loading message
- [ ] Confirm LRU eviction works when cache limits exceeded
- [ ] Check cache stats endpoint returns correct data
- [ ] Test timeout handling for slow S3 downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)