### PR TITLE
feat: Display actual tool calls in View button modals

### DIFF
--- a/agent/src/ai_agent/api_server.py
+++ b/agent/src/ai_agent/api_server.py
@@ -1030,6 +1030,7 @@ def create_app() -> Sanic:
                                     title=f"{display_name} Investigation",
                                     context_text=f"_Investigating: {message[:100]}{'...' if len(message) > 100 else ''}_",
                                     phases={},  # Empty - will be populated dynamically
+                                    run_id=run_id,
                                 )
 
                                 # Update the initial message with dashboard format
@@ -1045,6 +1046,7 @@ def create_app() -> Sanic:
                                     channel_id=channel_id,
                                     message_ts=message_ts,
                                     thread_ts=thread_ts,
+                                    run_id=run_id,
                                     title=f"{display_name} Investigation",
                                 )
                                 slack_hooks = SlackUpdateHooks(

--- a/agent/src/ai_agent/core/investigation_orchestrator.py
+++ b/agent/src/ai_agent/core/investigation_orchestrator.py
@@ -96,6 +96,7 @@ class InvestigationOrchestrator:
         severity: str | None = None,
         title: str = "IncidentFox Investigation",
         context: str | None = None,
+        run_id: str | None = None,
     ) -> InvestigationResult:
         """
         Run an investigation with real-time Slack updates.
@@ -108,6 +109,7 @@ class InvestigationOrchestrator:
             severity: Optional severity level
             title: Dashboard title
             context: Optional additional context
+            run_id: Optional agent run ID for tool call tracking
 
         Returns:
             InvestigationResult with findings and phase results
@@ -125,6 +127,7 @@ class InvestigationOrchestrator:
                 incident_id=incident_id,
                 severity=severity,
                 context_text=f"_Investigating: {prompt[:100]}{'...' if len(prompt) > 100 else ''}_",
+                run_id=run_id,
             )
 
             result = await self.slack_client.chat_postMessage(
@@ -147,6 +150,7 @@ class InvestigationOrchestrator:
                 channel_id=channel_id,
                 message_ts=message_ts,
                 thread_ts=thread_ts,
+                run_id=run_id,
                 incident_id=incident_id,
                 severity=severity,
                 title=title,

--- a/agent/src/ai_agent/core/slack_hooks.py
+++ b/agent/src/ai_agent/core/slack_hooks.py
@@ -400,6 +400,7 @@ class SlackUpdateState:
     channel_id: str
     message_ts: str
     thread_ts: str | None = None
+    run_id: str | None = None  # Agent run ID for fetching tool calls
 
     # Phase status tracking (category -> status)
     phase_status: dict[str, str] = field(default_factory=dict)
@@ -753,6 +754,7 @@ class SlackUpdateHooks(RunHooks):
                 severity = self.state.severity
                 channel_id = self.state.channel_id
                 message_ts = self.state.message_ts
+                run_id = self.state.run_id
 
             # Run callbacks outside the lock to avoid deadlock
             for phase, results in phase_complete_callbacks:
@@ -765,6 +767,7 @@ class SlackUpdateHooks(RunHooks):
                 incident_id=incident_id,
                 severity=severity,
                 phases=active_phases,
+                run_id=run_id,
             )
 
             # CRITICAL: This Slack API call can hang on network issues
@@ -854,6 +857,7 @@ class SlackUpdateHooks(RunHooks):
                 severity = self.state.severity
                 channel_id = self.state.channel_id
                 message_ts = self.state.message_ts
+                run_id = self.state.run_id
 
             # Build final dashboard with dynamic phases (outside lock)
             blocks = build_investigation_dashboard(
@@ -865,6 +869,7 @@ class SlackUpdateHooks(RunHooks):
                 confidence=confidence,
                 show_actions=True,
                 phases=active_phases,
+                run_id=run_id,
             )
 
             await self.slack_client.chat_update(


### PR DESCRIPTION
## Summary
- View buttons on investigation phases now show actual tool calls instead of placeholder text
- Fetches tool calls from config service API using the run_id embedded in button values
- Groups and filters tool calls by category (kubernetes, coralogix, aws, etc.)
- Displays tool name, input parameters, output, status, and duration in a modal

## Test plan
- [ ] Run an investigation via Slack
- [ ] Click a View button on a completed phase (e.g., Kubernetes, Coralogix)
- [ ] Verify modal shows actual tool calls with inputs/outputs
- [ ] Verify truncation works for long outputs
- [ ] Verify legacy messages (without run_id) show informational message

🤖 Generated with [Claude Code](https://claude.com/claude-code)