### PR TITLE
fix: Handle empty trees in knowledge_base stats endpoint

### DIFF
--- a/knowledge_base/api_server.py
+++ b/knowledge_base/api_server.py
@@ -54,6 +54,10 @@ def _detect_embedding_info(tree: Tree) -> tuple[str, int]:
     Returns:
         tuple of (embedding_key, embedding_dimension)
     """
+    # Handle empty/None trees
+    if tree is None or not hasattr(tree, "all_nodes") or not tree.all_nodes:
+        return "OpenAI", 1536
+
     for node in tree.all_nodes.values():
         if hasattr(node, "embeddings") and node.embeddings:
             keys = list(node.embeddings.keys())
@@ -999,6 +1003,16 @@ async def get_tree_stats(tree: Optional[str] = None):
         raise HTTPException(status_code=404, detail=f"Tree not found: {tree_name}")
 
     raptor_tree = ra.tree
+    # Handle empty/None trees (newly created trees with no documents)
+    if raptor_tree is None:
+        return TreeStatsResponse(
+            tree=tree_name,
+            total_nodes=0,
+            layers=0,
+            leaf_nodes=0,
+            summary_nodes=0,
+            layer_counts={},
+        )
     all_nodes = raptor_tree.all_nodes if hasattr(raptor_tree, "all_nodes") else {}
 
     # Use layer_to_nodes if available (more reliable than node.layer attribute)


### PR DESCRIPTION
## Summary
- Fix 500 error when viewing stats for newly created (empty) trees
- Newly created trees have `ra.tree = None` until documents are added

## Changes
- Add null check in `_detect_embedding_info()` for empty/None trees
- Return empty stats (zeros) for trees with no documents

🤖 Generated with Claude Code