### PR TITLE
fix: Resolve helm deployment timeout for slow-starting RAG services

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -201,50 +201,18 @@ jobs:
       - name: Deploy with Helm
         working-directory: charts
         run: |
+          # Increased timeout for slow-starting services (ultimate-rag downloads from S3 + loads model)
           helm upgrade --install incidentfox ./incidentfox \
             -n ${{ env.HELM_NAMESPACE }} \
             -f incidentfox/values.prod.yaml \
             --no-hooks \
             --force \
             --wait \
-            --timeout 10m
+            --timeout 15m
 
-      - name: Rollout restart deployments
-        run: |
-          # Force pods to pull new images
-          # Note: ai-pipeline is a CronJob, not a Deployment, so skip rollout restart
-          # Note: ultimate-rag may not be deployed yet (disabled by default)
-          if [ "${{ github.event.inputs.services }}" = "all" ]; then
-            kubectl rollout restart deployment/incidentfox-agent \
-              deployment/incidentfox-config-service \
-              deployment/incidentfox-knowledge-base \
-              deployment/incidentfox-orchestrator \
-              deployment/incidentfox-web-ui \
-              -n ${{ env.HELM_NAMESPACE }}
-            # Optional: restart ultimate-rag if deployed
-            kubectl rollout restart deployment/incidentfox-ultimate-rag -n ${{ env.HELM_NAMESPACE }} 2>/dev/null || true
-          elif [ "${{ github.event.inputs.services }}" = "ai-pipeline" ]; then
-            echo "ai-pipeline is a CronJob - no rollout restart needed"
-          else
-            kubectl rollout restart deployment/incidentfox-${{ github.event.inputs.services }} \
-              -n ${{ env.HELM_NAMESPACE }}
-          fi
-
-      - name: Wait for rollout
-        run: |
-          if [ "${{ github.event.inputs.services }}" = "all" ]; then
-            kubectl rollout status deployment/incidentfox-agent -n ${{ env.HELM_NAMESPACE }} --timeout=10m
-            kubectl rollout status deployment/incidentfox-config-service -n ${{ env.HELM_NAMESPACE }} --timeout=10m
-            kubectl rollout status deployment/incidentfox-knowledge-base -n ${{ env.HELM_NAMESPACE }} --timeout=10m
-            kubectl rollout status deployment/incidentfox-orchestrator -n ${{ env.HELM_NAMESPACE }} --timeout=10m
-            kubectl rollout status deployment/incidentfox-web-ui -n ${{ env.HELM_NAMESPACE }} --timeout=10m
-            # Optional: wait for ultimate-rag if deployed
-            kubectl rollout status deployment/incidentfox-ultimate-rag -n ${{ env.HELM_NAMESPACE }} --timeout=10m 2>/dev/null || true
-          elif [ "${{ github.event.inputs.services }}" = "ai-pipeline" ]; then
-            echo "ai-pipeline is a CronJob - no rollout status needed"
-          else
-            kubectl rollout status deployment/incidentfox-${{ github.event.inputs.services }} -n ${{ env.HELM_NAMESPACE }} --timeout=10m
-          fi
+      # Note: rollout restart is NOT needed after helm upgrade --force
+      # The --force flag already recreates pods, and --wait ensures they're ready
+      # Removing the redundant restart avoids double-waiting for slow-starting services
 
       - name: Verify deployment
         run: |

--- a/charts/incidentfox/templates/knowledge-base.yaml
+++ b/charts/incidentfox/templates/knowledge-base.yaml
@@ -102,11 +102,21 @@ spec:
           volumeMounts:
             - name: trees-volume
               mountPath: /app/trees
+          # Startup probe: allows long startup time for S3 download + model loading
+          # Once startup probe passes, liveness/readiness kick in with shorter timeouts
+          startupProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.services.knowledgeBase.servicePort }}
+            initialDelaySeconds: {{ .Values.services.knowledgeBase.startupProbe.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.services.knowledgeBase.startupProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.services.knowledgeBase.startupProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.services.knowledgeBase.startupProbe.failureThreshold | default 30 }}
           readinessProbe:
             httpGet:
               path: /health
               port: {{ .Values.services.knowledgeBase.servicePort }}
-            initialDelaySeconds: {{ .Values.services.knowledgeBase.readinessProbe.initialDelaySeconds | default 120 }}
+            initialDelaySeconds: {{ .Values.services.knowledgeBase.readinessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.services.knowledgeBase.readinessProbe.periodSeconds | default 10 }}
             timeoutSeconds: {{ .Values.services.knowledgeBase.readinessProbe.timeoutSeconds | default 5 }}
           {{- if .Values.services.knowledgeBase.livenessProbe.enabled }}
@@ -114,7 +124,7 @@ spec:
             httpGet:
               path: {{ .Values.services.knowledgeBase.livenessProbe.path | default "/health" }}
               port: {{ .Values.services.knowledgeBase.servicePort }}
-            initialDelaySeconds: {{ .Values.services.knowledgeBase.livenessProbe.initialDelaySeconds | default 180 }}
+            initialDelaySeconds: {{ .Values.services.knowledgeBase.livenessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.services.knowledgeBase.livenessProbe.periodSeconds | default 30 }}
             timeoutSeconds: {{ .Values.services.knowledgeBase.livenessProbe.timeoutSeconds | default 10 }}
           {{- end }}

--- a/charts/incidentfox/templates/ultimate-rag.yaml
+++ b/charts/incidentfox/templates/ultimate-rag.yaml
@@ -102,11 +102,21 @@ spec:
           volumeMounts:
             - name: trees-volume
               mountPath: /app/trees
+          # Startup probe: allows long startup time for S3 download + model loading
+          # Once startup probe passes, liveness/readiness kick in with shorter timeouts
+          startupProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.services.ultimateRag.servicePort }}
+            initialDelaySeconds: {{ .Values.services.ultimateRag.startupProbe.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.services.ultimateRag.startupProbe.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.services.ultimateRag.startupProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.services.ultimateRag.startupProbe.failureThreshold | default 30 }}
           readinessProbe:
             httpGet:
               path: /health
               port: {{ .Values.services.ultimateRag.servicePort }}
-            initialDelaySeconds: {{ .Values.services.ultimateRag.readinessProbe.initialDelaySeconds | default 120 }}
+            initialDelaySeconds: {{ .Values.services.ultimateRag.readinessProbe.initialDelaySeconds | default 5 }}
             periodSeconds: {{ .Values.services.ultimateRag.readinessProbe.periodSeconds | default 10 }}
             timeoutSeconds: {{ .Values.services.ultimateRag.readinessProbe.timeoutSeconds | default 5 }}
           {{- if .Values.services.ultimateRag.livenessProbe.enabled }}
@@ -114,7 +124,7 @@ spec:
             httpGet:
               path: {{ .Values.services.ultimateRag.livenessProbe.path | default "/health" }}
               port: {{ .Values.services.ultimateRag.servicePort }}
-            initialDelaySeconds: {{ .Values.services.ultimateRag.livenessProbe.initialDelaySeconds | default 180 }}
+            initialDelaySeconds: {{ .Values.services.ultimateRag.livenessProbe.initialDelaySeconds | default 10 }}
             periodSeconds: {{ .Values.services.ultimateRag.livenessProbe.periodSeconds | default 30 }}
             timeoutSeconds: {{ .Values.services.ultimateRag.livenessProbe.timeoutSeconds | default 10 }}
           {{- end }}

--- a/charts/incidentfox/values.yaml
+++ b/charts/incidentfox/values.yaml
@@ -332,14 +332,22 @@ services:
       limits:
         cpu: "2"
         memory: "12Gi"
+    # Startup probe allows long startup time (S3 download + model load)
+    # 30s initial + 30 failures * 10s = up to 5 min 30s startup time
+    startupProbe:
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 30
+    # After startup probe passes, shorter delays for normal operation
     readinessProbe:
-      initialDelaySeconds: 120
+      initialDelaySeconds: 5
       periodSeconds: 10
       timeoutSeconds: 5
     livenessProbe:
       enabled: true
       path: /health
-      initialDelaySeconds: 180
+      initialDelaySeconds: 10
       periodSeconds: 30
       timeoutSeconds: 10
     pdb:
@@ -384,14 +392,22 @@ services:
       limits:
         cpu: "2"
         memory: "12Gi"
+    # Startup probe allows long startup time (S3 download + model load)
+    # 30s initial + 30 failures * 10s = up to 5 min 30s startup time
+    startupProbe:
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 30
+    # After startup probe passes, shorter delays for normal operation
     readinessProbe:
-      initialDelaySeconds: 120
+      initialDelaySeconds: 5
       periodSeconds: 10
       timeoutSeconds: 5
     livenessProbe:
       enabled: true
       path: /health
-      initialDelaySeconds: 180
+      initialDelaySeconds: 10
       periodSeconds: 30
       timeoutSeconds: 10
     pdb:


### PR DESCRIPTION
## Summary
- Add `startupProbe` to ultimate-rag and knowledge-base deployments (allows ~5.5 min startup window)
- Increase helm timeout from 10m → 15m for safety margin
- Remove redundant `kubectl rollout restart` after `helm upgrade --force` (was causing double-wait)

## Root Cause
The `context deadline exceeded` error occurred because:
1. RAG services have long startup times (S3 download + model loading)
2. `readinessProbe.initialDelaySeconds: 120` meant first health check at 2 min
3. Helm `--wait --timeout 10m` would timeout waiting for pods
4. Then a separate `rollout restart` restarted ALL pods again, doubling wait time

## Test plan
- [ ] Re-run the GHA deploy workflow with `all` services
- [ ] Verify ultimate-rag pod starts successfully within 15m
- [ ] Confirm no `context deadline exceeded` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)