### PR TITLE
feat: Upgrade memory-intensive node to r6i.xlarge (32GB)

### DIFF
--- a/charts/incidentfox/templates/ultimate-rag.yaml
+++ b/charts/incidentfox/templates/ultimate-rag.yaml
@@ -25,6 +25,10 @@ metadata:
     app.kubernetes.io/component: ultimate-rag
 spec:
   replicas: {{ .Values.services.ultimateRag.replicas }}
+  # RollingUpdate for zero-downtime deployments (requires node with 2x memory)
+  # Use Recreate if node memory is limited
+  strategy:
+    type: {{ .Values.services.ultimateRag.strategy | default "RollingUpdate" }}
   selector:
     matchLabels:
       app.kubernetes.io/name: incidentfox-ultimate-rag

--- a/infra/terraform/envs/pilot/main.tf
+++ b/infra/terraform/envs/pilot/main.tf
@@ -73,6 +73,15 @@ module "eks" {
   node_min_size       = var.node_min_size
   node_max_size       = var.node_max_size
   node_desired_size   = var.node_desired_size
+
+  # Memory-intensive node group for RAG workloads
+  memory_intensive_nodegroup_enabled = var.memory_intensive_nodegroup_enabled
+  memory_intensive_instance_types    = var.memory_intensive_instance_types
+  memory_intensive_disk_size         = var.memory_intensive_disk_size
+  memory_intensive_min_size          = var.memory_intensive_min_size
+  memory_intensive_max_size          = var.memory_intensive_max_size
+  memory_intensive_desired_size      = var.memory_intensive_desired_size
+
   tags                = local.tags
 }
 

--- a/infra/terraform/envs/pilot/variables.tf
+++ b/infra/terraform/envs/pilot/variables.tf
@@ -146,6 +146,40 @@ variable "eks_node_security_group_id" {
   description = "Security group to allow DB ingress from (BYO EKS cluster SG or node SG)"
 }
 
+# Memory-intensive node group for RAG/knowledge-base workloads
+variable "memory_intensive_nodegroup_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable memory-intensive node group for RAG workloads"
+}
+
+variable "memory_intensive_instance_types" {
+  type        = list(string)
+  default     = ["r6i.xlarge"]
+  description = "Instance types for memory-intensive nodegroup (32GB RAM for RAG trees + rolling updates)"
+}
+
+variable "memory_intensive_disk_size" {
+  type        = number
+  default     = 50
+  description = "Disk size in GB for memory-intensive nodes"
+}
+
+variable "memory_intensive_min_size" {
+  type    = number
+  default = 0
+}
+
+variable "memory_intensive_max_size" {
+  type    = number
+  default = 2
+}
+
+variable "memory_intensive_desired_size" {
+  type    = number
+  default = 1
+}
+
 # ESO permissions
 variable "eso_allowed_secret_arns" {
   type        = list(string)

--- a/infra/terraform/modules/eks/variables.tf
+++ b/infra/terraform/modules/eks/variables.tf
@@ -80,8 +80,8 @@ variable "memory_intensive_nodegroup_enabled" {
 
 variable "memory_intensive_instance_types" {
   type        = list(string)
-  default     = ["t3.xlarge"]
-  description = "Instance types for memory-intensive nodegroup (16GB RAM)"
+  default     = ["r6i.xlarge"]
+  description = "Instance types for memory-intensive nodegroup (32GB RAM for RAG + rolling updates)"
 }
 
 variable "memory_intensive_disk_size" {


### PR DESCRIPTION
## Summary
- Upgrade default memory-intensive instance type from `t3.xlarge` (16GB) to `r6i.xlarge` (32GB)
- Add memory-intensive node group variables to pilot terraform environment
- Make deployment strategy configurable (default: RollingUpdate)

## Why
The 32GB node enables:
- **Zero-downtime RollingUpdate deployments** - room for 2× 8Gi pods during rolling update
- **Support for 2-3 RAG trees** - future multi-tree workloads
- **No more scheduling deadlocks** - previous 16GB node couldn't fit 2 pods simultaneously

## Cost Impact
- ~$60/mo increase ($182 vs $120 for t3.xlarge)
- Acceptable trade-off for production SaaS reliability

## Already Applied
The node group upgrade has already been applied manually via AWS CLI:
- Created `memory-intensive-nodes-r6i` with `r6i.xlarge`
- Migrated ultimate-rag pod to new node
- Deleted old `memory-intensive-nodes` with `t3.xlarge`

This PR documents the change in terraform for future deployments.

## Test plan
- [x] Node group created and verified (31GB allocatable)
- [x] ultimate-rag pod successfully migrated
- [x] Pod health verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)