### PR TITLE
fix: Add pickle compatibility shim for legacy RAPTOR trees

### DIFF
--- a/ultimate_rag/api/server.py
+++ b/ultimate_rag/api/server.py
@@ -11,6 +11,21 @@ FastAPI server that exposes all Ultimate RAG capabilities:
 
 import logging
 import os
+import sys
+
+# Pickle compatibility shim for legacy RAPTOR trees.
+# Old pickle files reference 'raptor.tree_structures' but the module is now
+# at 'knowledge_base.raptor.tree_structures'. This shim creates module aliases
+# so pickle.load() can find the classes.
+try:
+    from knowledge_base import raptor as kb_raptor
+
+    sys.modules["raptor"] = kb_raptor
+    # Also alias submodules that might be referenced
+    if hasattr(kb_raptor, "tree_structures"):
+        sys.modules["raptor.tree_structures"] = kb_raptor.tree_structures
+except ImportError:
+    pass  # knowledge_base not available, skip shim
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path


### PR DESCRIPTION
## Summary
Fix tree loading failure: `No module named 'raptor'`

Old pickle files reference `raptor.tree_structures` but the module is now at `knowledge_base.raptor.tree_structures`. This shim creates module aliases so `pickle.load()` can deserialize legacy trees.

## Issue
```
Failed to load tree from /app/trees/mega_ultra_v2.pkl: No module named 'raptor'
```

## Fix
Added module alias shim at server startup that maps:
- `raptor` → `knowledge_base.raptor`
- `raptor.tree_structures` → `knowledge_base.raptor.tree_structures`

## Test plan
- [ ] Rebuild and push Docker image
- [ ] Restart ultimate-rag deployment
- [ ] Verify tree loads successfully via `/api/v1/trees`

🤖 Generated with [Claude Code](https://claude.com/claude-code)