### PR TITLE
fix: Add umap-learn dependency for RAPTOR tree deserialization

### DIFF
--- a/ultimate_rag/requirements.txt
+++ b/ultimate_rag/requirements.txt
@@ -6,6 +6,7 @@ numpy==1.26.3
 scikit-learn
 torch
 transformers==4.48.0
+umap-learn==0.5.5  # Required for RAPTOR tree pickle deserialization
 
 # NLP/Embeddings
 sentence-transformers==2.2.2


### PR DESCRIPTION
## Summary

Add missing `umap-learn` dependency to ultimate_rag requirements.

The RAPTOR pickle files contain UMAP objects that require the `umap-learn` package for deserialization. Without it, tree loading fails with:
```
Failed to load tree from /app/trees/mega_ultra_v2.pkl: No module named 'umap'
```

This was discovered after merging PR #173 which fixed the `raptor` module import path.

## Test plan

- [ ] Merge and trigger ultimate-rag deployment
- [ ] Verify pod logs show "Loaded tree 'mega_ultra_v2'" (no import errors)
- [ ] Verify `/api/v1/tree/stats?tree=mega_ultra_v2` returns 200
- [ ] Verify web UI Knowledge Base page loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)