### PR TITLE
fix: Merge all alembic heads and use 'upgrade heads' in GHA

### DIFF
--- a/.github/workflows/run-migrations.yml
+++ b/.github/workflows/run-migrations.yml
@@ -18,9 +18,10 @@ on:
       command:
         description: 'Alembic command to run'
         required: true
-        default: 'upgrade head'
+        default: 'upgrade heads'
         type: choice
         options:
+          - upgrade heads
           - upgrade head
           - current
           - history
@@ -74,8 +75,8 @@ jobs:
             CMD="${{ github.event.inputs.command }}"
             DRY_RUN="${{ github.event.inputs.dry_run }}"
           else
-            # Automatic trigger: always upgrade head
-            CMD="upgrade head"
+            # Automatic trigger: use 'heads' to handle multiple branches
+            CMD="upgrade heads"
             DRY_RUN="false"
           fi
 

--- a/config_service/alembic/versions/20260128_visitor_playground.py
+++ b/config_service/alembic/versions/20260128_visitor_playground.py
@@ -5,7 +5,7 @@ visitor playground feature where users can try IncidentFox without
 a paid account.
 
 Revision ID: 20260128_visitor_playground
-Revises: 20260127_teachings, 20260125_agent_feedback
+Revises: 20260127_teachings, 20260125_agent_feedback, 20260119_tool_calls
 Create Date: 2026-01-28
 """
 
@@ -14,7 +14,11 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "20260128_visitor_playground"
-down_revision = ("20260127_teachings", "20260125_agent_feedback")
+# Merge all three existing heads into one:
+# - 20260127_teachings (from 20260122_agent_tracking)
+# - 20260125_agent_feedback (from 20260122_agent_tracking)
+# - 20260119_tool_calls (orphan branch from 20260118_service_dependencies)
+down_revision = ("20260127_teachings", "20260125_agent_feedback", "20260119_tool_calls")
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
Fixes the migration workflow failure caused by multiple head revisions in alembic.

## Changes
- Updated visitor playground migration to merge all 3 existing heads (was only merging 2)
- Changed GHA workflow to use `upgrade heads` (plural) instead of `upgrade head`

## Context
The migration failed with: `Multiple head revisions are present for given argument 'head'`

This was caused by:
1. The migration only merged 2 of the 3 existing heads
2. `20260119_tool_calls` was an orphan branch that wasn't included

After this fix, there will be a single head revision going forward.

🤖 Generated with Claude Code