### PR TITLE
fix: Handle visitor auth in config endpoints

### DIFF
--- a/config_service/src/api/routes/config_v2.py
+++ b/config_service/src/api/routes/config_v2.py
@@ -98,6 +98,9 @@ def _resolve_team_identity(
             elif auth_kind == "oidc" and oidc_principal:
                 if oidc_principal.org_id and oidc_principal.team_node_id:
                     return oidc_principal.org_id, oidc_principal.team_node_id
+            elif auth_kind == "visitor" and oidc_principal:
+                if oidc_principal.org_id and oidc_principal.team_node_id:
+                    return oidc_principal.org_id, oidc_principal.team_node_id
         except Exception as e:
             logger.debug("bearer_token_auth_failed", error=str(e))
 


### PR DESCRIPTION
## Summary
- Adds visitor token handling in `_resolve_team_identity()` function
- Fixes 401 error on `GET /api/v1/config/me` for visitor users

## Problem
Visitors logging in via the playground were getting 401 errors when accessing the agent topology page. The `_resolve_team_identity()` function in `config_v2.py` was not handling `auth_kind == "visitor"`, causing it to fall through and return 401.

## Solution
Added handling for visitor tokens to extract `org_id` and `team_node_id` from the JWT claims:

```python
elif auth_kind == "visitor" and oidc_principal:
    if oidc_principal.org_id and oidc_principal.team_node_id:
        return oidc_principal.org_id, oidc_principal.team_node_id
```

Write access remains blocked by `_check_visitor_write_access()`.

## Test plan
- [ ] Log in as visitor via email
- [ ] Navigate to agent topology page
- [ ] Verify no 401 errors in console
- [ ] Verify config loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)