### PR TITLE
fix: Use localStorage for visitor onboarding state

### DIFF
--- a/web_ui/src/app/admin/page.tsx
+++ b/web_ui/src/app/admin/page.tsx
@@ -96,12 +96,13 @@ export default function AdminHomePage() {
   const [services, setServices] = useState<ServiceHealth[]>([]);
   const [integrations, setIntegrations] = useState<IntegrationHealth[]>([]);
 
-  // Onboarding state
+  // Onboarding state - visitors use localStorage only
+  const isVisitor = identity?.auth_kind === 'visitor';
   const {
     shouldShowWelcome,
     markWelcomeSeen,
     markFirstAgentRunCompleted,
-  } = useOnboarding();
+  } = useOnboarding({ isVisitor });
   const [showWelcomeModal, setShowWelcomeModal] = useState(false);
 
   // Show welcome modal on first visit

--- a/web_ui/src/app/settings/page.tsx
+++ b/web_ui/src/app/settings/page.tsx
@@ -121,7 +121,9 @@ export default function SettingsPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { identity, loading: identityLoading } = useIdentity();
-  const { resetOnboarding } = useOnboarding();
+  // Visitors use localStorage only for onboarding state
+  const isVisitor = identity?.auth_kind === 'visitor';
+  const { resetOnboarding } = useOnboarding({ isVisitor });
 
   // Tab state - synced with URL query param
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');

--- a/web_ui/src/app/team/agent-runs/page.tsx
+++ b/web_ui/src/app/team/agent-runs/page.tsx
@@ -98,7 +98,9 @@ const AGENT_COLORS: Record<string, string> = {
 
 export default function TeamAgentRunsPage() {
   const { identity } = useIdentity();
-  const { state: onboardingState, markFirstAgentRunCompleted, setQuickStartStep } = useOnboarding();
+  // Visitors use localStorage only for onboarding state
+  const isVisitor = identity?.auth_kind === 'visitor';
+  const { state: onboardingState, markFirstAgentRunCompleted, setQuickStartStep } = useOnboarding({ isVisitor });
   const [runs, setRuns] = useState<AgentRun[]>([]);
   const [loading, setLoading] = useState(true);
   const [expandedId, setExpandedId] = useState<string | null>(null);

--- a/web_ui/src/app/team/page.tsx
+++ b/web_ui/src/app/team/page.tsx
@@ -50,12 +50,13 @@ export default function TeamDashboardPage() {
   const [activities, setActivities] = useState<ActivityItem[]>([]);
   const [pending, setPending] = useState<PendingItems>({ configChanges: 0, knowledgeChanges: 0 });
 
-  // Onboarding state
+  // Onboarding state - visitors use localStorage only
+  const isVisitor = identity?.auth_kind === 'visitor';
   const {
     shouldShowWelcome,
     markWelcomeSeen,
     markFirstAgentRunCompleted,
-  } = useOnboarding();
+  } = useOnboarding({ isVisitor });
   const [showWelcomeModal, setShowWelcomeModal] = useState(false);
 
   // Show welcome modal on first visit

--- a/web_ui/src/components/onboarding/ContinueOnboardingButton.tsx
+++ b/web_ui/src/components/onboarding/ContinueOnboardingButton.tsx
@@ -7,6 +7,8 @@ import { ArrowRight, X } from 'lucide-react';
 
 interface ContinueOnboardingButtonProps {
   onContinue: (step: number, step4Action?: Step4NextAction) => void;
+  /** When true, uses localStorage only for onboarding state (for visitors) */
+  isVisitor?: boolean;
 }
 
 const STEP_NAMES: { [key: number]: string } = {
@@ -23,9 +25,9 @@ const DEFAULT_STEP4_PROGRESS: Step4Progress = {
   visitedAgentConfig: false,
 };
 
-export function ContinueOnboardingButton({ onContinue }: ContinueOnboardingButtonProps) {
+export function ContinueOnboardingButton({ onContinue, isVisitor = false }: ContinueOnboardingButtonProps) {
   const pathname = usePathname();
-  const { clearQuickStartStep } = useOnboarding();
+  const { clearQuickStartStep } = useOnboarding({ isVisitor });
   const [dismissed, setDismissed] = useState(false);
   const [localStep, setLocalStep] = useState<number | null>(null);
   const [localStep4Progress, setLocalStep4Progress] = useState<Step4Progress>(DEFAULT_STEP4_PROGRESS);

--- a/web_ui/src/components/onboarding/OnboardingWrapper.tsx
+++ b/web_ui/src/components/onboarding/OnboardingWrapper.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react';
 import { ContinueOnboardingButton } from './ContinueOnboardingButton';
 import { QuickStartWizard } from './QuickStartWizard';
+import { useIdentity } from '@/lib/useIdentity';
 import type { Step4NextAction } from '@/lib/useOnboarding';
 
 interface OnboardingWrapperProps {
@@ -14,6 +15,8 @@ interface OnboardingWrapperProps {
  * Should be placed high in the component tree to appear on all pages.
  */
 export function OnboardingWrapper({ children }: OnboardingWrapperProps) {
+  const { identity } = useIdentity();
+  const isVisitor = identity?.auth_kind === 'visitor';
   const [showWizard, setShowWizard] = useState(false);
   const [wizardInitialStep, setWizardInitialStep] = useState(1);
 
@@ -44,7 +47,7 @@ export function OnboardingWrapper({ children }: OnboardingWrapperProps) {
       {children}
 
       {/* Floating continue button - appears when user navigates away mid-wizard */}
-      <ContinueOnboardingButton onContinue={handleContinueOnboarding} />
+      <ContinueOnboardingButton onContinue={handleContinueOnboarding} isVisitor={isVisitor} />
 
       {/* Quick Start Wizard modal */}
       {showWizard && (
@@ -53,6 +56,7 @@ export function OnboardingWrapper({ children }: OnboardingWrapperProps) {
           onRunAgent={handleRunAgent}
           onSkip={handleSkip}
           initialStep={wizardInitialStep}
+          isVisitor={isVisitor}
         />
       )}
     </>

--- a/web_ui/src/components/onboarding/QuickStartWizard.tsx
+++ b/web_ui/src/components/onboarding/QuickStartWizard.tsx
@@ -29,13 +29,15 @@ interface QuickStartWizardProps {
   onRunAgent: () => void;
   onSkip: () => void;
   initialStep?: number;
+  /** When true, uses localStorage only for onboarding state (for visitors) */
+  isVisitor?: boolean;
 }
 
 const TOTAL_STEPS = 6;
 
-export function QuickStartWizard({ onClose, onRunAgent, onSkip, initialStep = 1 }: QuickStartWizardProps) {
+export function QuickStartWizard({ onClose, onRunAgent, onSkip, initialStep = 1, isVisitor = false }: QuickStartWizardProps) {
   const [currentStep, setCurrentStep] = useState(initialStep);
-  const { setQuickStartStep, clearQuickStartStep, markStep4IntegrationsVisited, markStep4AgentConfigVisited } = useOnboarding();
+  const { setQuickStartStep, clearQuickStartStep, markStep4IntegrationsVisited, markStep4AgentConfigVisited } = useOnboarding({ isVisitor });
 
   // Handle navigation away - save next step so user can resume
   const handleNavigateAway = () => {


### PR DESCRIPTION
## Summary
- Adds `isVisitor` option to `useOnboarding` hook
- When `isVisitor` is true, uses localStorage only (no server calls)
- Fixes welcome modal showing repeatedly for visitors

## Problem
Visitors were seeing the welcome modal on every page load because:
1. `markWelcomeSeen()` tried to `PATCH /api/team/preferences` → got 403 (visitors can't write)
2. State was saved to localStorage temporarily
3. On reload, `loadState()` fetched from server first
4. Server returned empty preferences (no `welcomeModalSeen: true`)
5. Modal showed again

## Solution
Add `isVisitor` option to `useOnboarding` hook:

```typescript
const { shouldShowWelcome, markWelcomeSeen } = useOnboarding({ isVisitor: true });
```

When `isVisitor` is true:
- `loadState()` reads from localStorage only (no server fetch)
- `updateState()` saves to localStorage only (no server PATCH)
- No 403 errors in console

## Files Changed
- `web_ui/src/lib/useOnboarding.ts` - Added `isVisitor` option
- `web_ui/src/components/onboarding/*` - Pass `isVisitor` prop
- `web_ui/src/app/team/page.tsx` - Pass `isVisitor` based on identity
- `web_ui/src/app/admin/page.tsx` - Pass `isVisitor` based on identity
- `web_ui/src/app/settings/page.tsx` - Pass `isVisitor` based on identity
- `web_ui/src/app/team/agent-runs/page.tsx` - Pass `isVisitor` based on identity

## Test plan
- [ ] Log in as visitor via email
- [ ] See welcome modal, click "Get Started"
- [ ] Refresh page - modal should NOT show again
- [ ] No 403 errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)