### PR TITLE
fix: Use correct TeachResult fields in TeachResponse

### DIFF
--- a/ultimate_rag/api/server.py
+++ b/ultimate_rag/api/server.py
@@ -1050,10 +1050,10 @@ class UltimateRAGServer:
                 )
 
                 return TeachResponse(
-                    success=result.status.value in ["added", "updated"],
+                    success=result.status.value in ["created", "merged"],
                     node_id=result.node_id,
                     status=result.status.value,
-                    message=result.message,
+                    message=result.action,
                 )
 
             except Exception as e:
@@ -1083,10 +1083,10 @@ class UltimateRAGServer:
             )
 
             return TeachResponse(
-                success=result.status.value in ["added", "updated"],
+                success=result.status.value in ["created", "merged"],
                 node_id=result.node_id,
                 status=result.status.value,
-                message=result.message,
+                message=result.action,
             )
 
         # ==================== Graph Routes ====================
@@ -2096,11 +2096,11 @@ class UltimateRAGServer:
 
                 # Map status to v1 format
                 status = result.status.value
-                message = result.message
+                message = result.action
 
-                if status == "added":
+                if status == "created":
                     message = "New knowledge successfully added to the knowledge base."
-                elif status == "updated":
+                elif status == "merged":
                     message = "Knowledge merged with existing similar content."
                 elif status == "duplicate":
                     message = "This knowledge already exists in the knowledge base."


### PR DESCRIPTION
## Summary

- **Fix incorrect field access**: `TeachResult` dataclass uses `action` field, not `message`
- **Fix incorrect status values**: `TeachStatus` enum has `created`/`merged`, not `added`/`updated`

### Changes

| Location | Before | After |
|----------|--------|-------|
| `result.message` | Accessing non-existent field | `result.action` |
| Success check | `["added", "updated"]` | `["created", "merged"]` |

### Affected endpoints

- `POST /teach`
- `POST /teach/correction`
- `POST /api/v1/teach`

### Context

The `TeachResult` dataclass in `ultimate_rag/agents/teaching.py` defines:
```python
@dataclass
class TeachResult:
    status: TeachStatus
    action: str = ""  # NOT 'message'
    ...
```

And `TeachStatus` enum:
```python
class TeachStatus(str, Enum):
    CREATED = "created"   # NOT 'added'
    MERGED = "merged"     # NOT 'updated'
    ...
```

## Test plan

- [ ] Verify `/teach` endpoint returns correct status values
- [ ] Verify `/teach/correction` endpoint works
- [ ] Verify `/api/v1/teach` endpoint returns proper messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)