### PR TITLE
fix: Remove duplicate isVisitor variable definition

### DIFF
--- a/web_ui/src/app/settings/page.tsx
+++ b/web_ui/src/app/settings/page.tsx
@@ -210,7 +210,6 @@ export default function SettingsPage() {
   const [newRoutingValue, setNewRoutingValue] = useState('');
 
   const isAdmin = identity?.role === 'admin';
-  const isVisitor = identity?.auth_kind === 'visitor';
   const canWrite = !isVisitor;
 
   // Theme toggle


### PR DESCRIPTION
## Summary
Fixed a Turbopack build error caused by the `isVisitor` variable being defined twice in the SettingsPage component. Removed the duplicate definition while keeping the initial one used by the useOnboarding hook.

## Changes
- Removed redundant `isVisitor` variable declaration at line 213
- The first declaration (line 129) is retained as it's used by the useOnboarding hook

## Testing
- Build now completes successfully with no TypeScript errors
- All functionality preserved