### PR TITLE
feat: Add QueryDecompositionStrategy for multi-hop queries

### DIFF
--- a/ultimate_rag/retrieval/retriever.py
+++ b/ultimate_rag/retrieval/retriever.py
@@ -28,6 +28,7 @@ from .strategies import (
     IncidentAwareStrategy,
     MultiQueryStrategy,
     QueryAnalysis,
+    QueryDecompositionStrategy,
     QueryIntent,
     RetrievalStrategy,
     RetrievedChunk,
@@ -143,6 +144,7 @@ class UltimateRetriever:
         # Initialize strategies
         self._strategies: Dict[str, RetrievalStrategy] = {
             "multi_query": MultiQueryStrategy(),
+            "query_decomposition": QueryDecompositionStrategy(),
             "hyde": HyDEStrategy(),
             "adaptive_depth": AdaptiveDepthStrategy(),
             "hybrid": HybridGraphTreeStrategy(),


### PR DESCRIPTION
## Summary

- Add `QueryDecompositionStrategy` for improved multi-hop query retrieval
- Uses LLM to decompose complex queries into simpler sub-questions
- Retrieves independently for each sub-query and merges results
- Boosts scores for chunks found by multiple sub-queries (20% per additional hit)

This is a clean implementation of the feature from PR #219, which had significant merge conflicts.

## How it works

For a query like "How does service A connect to service B and what are the error handling procedures?":

1. LLM decomposes into sub-questions:
   - "How does service A connect to service B?"
   - "What are the error handling procedures for service A?"
   - "What are the error handling procedures for service B?"

2. Retrieves for each sub-question independently

3. Merges results, boosting chunks found by multiple sub-queries

## Test plan

- [ ] Verify strategy imports correctly
- [ ] Test query decomposition with various query types
- [ ] Validate score boosting for multi-hit chunks
- [ ] Integration test with UltimateRetriever

🤖 Generated with [Claude Code](https://claude.com/claude-code)