### PR TITLE
fix(slack-bot): Use message_ts as cache key for View Session

### DIFF
--- a/slack-bot/message_builder.py
+++ b/slack-bot/message_builder.py
@@ -179,6 +179,7 @@ def build_progress_message(
     loading_url: Optional[str] = None,
     done_url: Optional[str] = None,
     thread_id: Optional[str] = None,
+    message_ts: Optional[str] = None,
     trigger_user_id: Optional[str] = None,
     trigger_text: Optional[str] = None,
 ) -> list:
@@ -432,7 +433,7 @@ def build_progress_message(
         )
         logger.warning(f"Progress message truncated. Had {len(blocks)} blocks.")
 
-    # View Session button
+    # View Session button - use message_ts as unique key for each message
     blocks.append(
         {
             "type": "actions",
@@ -441,7 +442,7 @@ def build_progress_message(
                     "type": "button",
                     "text": {"type": "plain_text", "text": "View Session"},
                     "action_id": "view_investigation_session",
-                    "value": thread_id or "unknown",
+                    "value": message_ts or thread_id or "unknown",
                 }
             ],
         }
@@ -457,6 +458,7 @@ def build_final_message(
     error: Optional[str] = None,
     done_url: Optional[str] = None,
     thread_id: Optional[str] = None,
+    message_ts: Optional[str] = None,
     result_images: Optional[List[dict]] = None,
     result_files: Optional[List[dict]] = None,
     trigger_user_id: Optional[str] = None,
@@ -688,7 +690,7 @@ def build_final_message(
             }
         )
 
-    # View Session button
+    # View Session button - use message_ts as unique key for each message
     blocks.append(
         {
             "type": "actions",
@@ -697,7 +699,7 @@ def build_final_message(
                     "type": "button",
                     "text": {"type": "plain_text", "text": "View Session"},
                     "action_id": "view_investigation_session",
-                    "value": thread_id or "unknown",
+                    "value": message_ts or thread_id or "unknown",
                 }
             ],
         }


### PR DESCRIPTION
## Description

Fixed a bug where clicking "View Session" on any message in a thread would always show the latest investigation instead of the specific message's investigation. The cache was keyed by `thread_id` (shared by all messages in a thread) instead of `message_ts` (unique per message).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issues

Closes #

## Changes Made

- Changed cache key from `thread_id` to `message_ts` throughout the codebase
- Updated message builders to accept and use `message_ts` for button values
- Updated View Session button handler to use `message_ts` from button value
- Added comments clarifying the cache key strategy

## Testing

Manual testing required in Slack to verify that clicking "View Session" on different messages in the same thread shows the correct investigation state.

### Test Plan

- [x] Code follows the project's style guidelines
- [ ] Unit tests added/updated
- [ ] Manual testing performed

## Deployment Notes

- [x] Backward compatible
- Note: With multiple slack-bot replicas, the in-memory cache may be unreliable. Consider scaling to 1 replica or implementing Redis-backed cache for HA deployments.