### PR TITLE
Update Coralogix video URL to Vimeo

### DIFF
--- a/slack-bot/onboarding.py
+++ b/slack-bot/onboarding.py
@@ -43,9 +43,9 @@ INTEGRATIONS: List[Dict[str, Any]] = [
         # Video block metadata
         "video": {
             "title": "How to Connect Coralogix to IncidentFox",
-            "title_url": "https://youtu.be/he5QrFKymAg",
-            "video_url": "https://www.youtube.com/embed/he5QrFKymAg?feature=oembed&autoplay=1",
-            "thumbnail_url": "https://i.ytimg.com/vi/he5QrFKymAg/hqdefault.jpg",
+            "title_url": "https://vimeo.com/1161578699?share=copy&fl=sv&fe=ci",
+            "video_url": "https://player.vimeo.com/video/1161578699?autoplay=1",
+            "thumbnail_url": "https://vumbnail.com/1161578699.jpg",
             "alt_text": "Coralogix setup tutorial",
             "description": "Step-by-step guide to connecting your Coralogix account",
         },


### PR DESCRIPTION
## Description

Updated the Coralogix integration setup tutorial video from YouTube to Vimeo in the Slack bot onboarding flow.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- Replaced YouTube video link with Vimeo tutorial video (ID: 1161578699)
- Updated video_url to use Vimeo embed format
- Updated thumbnail URL to Vimeo's thumbnail service

## Testing

- [x] Manual verification of the URL structure and format

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Backward compatible