### PR TITLE
fix(slack-bot): Add links.embed:write scope for video blocks

### DIFF
--- a/slack-bot/app.py
+++ b/slack-bot/app.py
@@ -69,6 +69,7 @@ SLACK_SCOPES = [
     "im:write",
     "links:read",
     "links:write",
+    "links.embed:write",
     "metadata.message:read",
     "mpim:history",
     "mpim:read",

--- a/slack-bot/slack-manifest.yaml
+++ b/slack-bot/slack-manifest.yaml
@@ -19,6 +19,9 @@ oauth_config:
       - reactions:write
       - im:history
       - groups:history
+      - links:read
+      - links:write
+      - links.embed:write
 settings:
   event_subscriptions:
     bot_events:


### PR DESCRIPTION
## Description

The Coralogix config modal was failing to open with a Slack API error: "Video validation failed: Bot scopes missing: [links.embed:write]". The modal includes a video block (Vimeo tutorial) which requires the `links.embed:write` scope.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `links.embed:write` to `SLACK_SCOPES` in app.py (OAuth installation)
- Added `links.embed:write` to slack-manifest.yaml (for consistency)

## Deployment Notes

- [x] Requires environment variable updates (new scope in OAuth)
- [x] Backward compatible

**Existing workspace installations** will need to re-authorize the app to get the new scope. New installations will get it automatically.