### PR TITLE
fix: Remove hardcoded secrets from test file

### DIFF
--- a/sre-agent/.claude/skills/test_backends_direct.py
+++ b/sre-agent/.claude/skills/test_backends_direct.py
@@ -30,7 +30,7 @@ def test_elasticsearch():
 
     url = "https://a6f123d4974844f938d66fd05676392b-1823852830.us-west-2.elb.amazonaws.com:9200"
     user = "elastic"
-    password = "0LDCTr7cf1PzvYES"
+    password = "REDACTED"  # Rotated - use env var or secrets manager
 
     auth = b64encode(f"{user}:{password}".encode()).decode()
     headers = {"Authorization": f"Basic {auth}", "Content-Type": "application/json"}
@@ -98,7 +98,7 @@ def test_grafana():
         "http://abffcf5b990ec4bd685aef627eb2daf1-1789943242.us-west-2.elb.amazonaws.com"
     )
     user = "admin"
-    password = "uDrDN1nix1zFBpdrAUF1"
+    password = "REDACTED"  # Rotated - use env var or secrets manager
 
     auth = b64encode(f"{user}:{password}".encode()).decode()
     headers = {"Authorization": f"Basic {auth}", "Content-Type": "application/json"}
@@ -143,7 +143,7 @@ def test_coralogix():
     print("CORALOGIX")
     print("=" * 60)
 
-    api_key = "cxtp_3yj3bxsoKG58al9qh4X8z7oursWOwZ"
+    api_key = "REDACTED"  # Rotated - use env var or secrets manager
     api_url = "https://ng-api-http.cx498.coralogix.com"
 
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
@@ -198,8 +198,8 @@ def test_datadog():
     print("DATADOG")
     print("=" * 60)
 
-    api_key = "e6226b3acf72e50fd9905559e1ccd2f4"
-    app_key = "08a8a6b503e98818a43dcd7e0a3f4055d20d2915"
+    api_key = "REDACTED"  # Rotated - use env var or secrets manager
+    app_key = "REDACTED"  # Rotated - use env var or secrets manager
     site = "us5.datadoghq.com"
 
     headers = {


### PR DESCRIPTION
## Summary
- Remove hardcoded API keys and passwords from test_backends_direct.py
- Replace with REDACTED placeholders
- Secrets have been rotated

## Urgency
**CRITICAL** - This is a security fix to remove secrets from the codebase before running BFG to clean git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)