### PR TITLE
chore: Add Confluence logo and video to integration

### DIFF
--- a/slack-bot/assets_config.py
+++ b/slack-bot/assets_config.py
@@ -47,6 +47,7 @@ INTEGRATION_LOGOS = {
     "jira": f"{ASSETS_BASE_URL}/integrations/jira.png",
     "linear": f"{ASSETS_BASE_URL}/integrations/linear.png",
     "notion": f"{ASSETS_BASE_URL}/integrations/notion.png",
+    "confluence": f"{ASSETS_BASE_URL}/integrations/confluence.png",
     "glean": f"{ASSETS_BASE_URL}/integrations/glean.png",
     "servicenow": f"{ASSETS_BASE_URL}/integrations/servicenow.png",
     # Infrastructure

--- a/slack-bot/onboarding.py
+++ b/slack-bot/onboarding.py
@@ -124,6 +124,14 @@ INTEGRATIONS: List[Dict[str, Any]] = [
         "icon": ":confluence:",
         "icon_fallback": ":notebook:",
         "description": "Search runbooks, documentation, and knowledge base articles.",
+        "video": {
+            "title": "How to Connect Confluence to IncidentFox",
+            "title_url": "https://vimeo.com/1161614962?share=copy&fl=sv&fe=ci",
+            "video_url": "https://player.vimeo.com/video/1161614962?autoplay=1",
+            "thumbnail_url": "https://vumbnail.com/1161614962.jpg",
+            "alt_text": "Confluence setup tutorial",
+            "description": "Step-by-step guide to connecting your Confluence account",
+        },
         "setup_instructions": (
             "*Setup Instructions:*\n"
             "1. Log into <https://id.atlassian.com/manage-profile/security/api-tokens|Atlassian API Tokens>\n"


### PR DESCRIPTION
## Description

Add Confluence integration logo mapping and setup video. Logo converted from AVIF to 128x128 PNG and uploaded to S3 at `s3://incidentfox-assets/slack/integrations/confluence.png`.

## Type of Change

- [x] 🔧 Refactoring / code cleanup

## Changes Made

- Added `confluence` to `INTEGRATION_LOGOS` mapping in `assets_config.py`
- Added Vimeo video block to Confluence integration config in `onboarding.py`
- Processed and uploaded Confluence logo to S3

## Testing

- [x] Self-review completed
- [x] Code follows Python style guidelines
- [x] Logo accessible at S3 URL (HTTP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)