### PR TITLE
docs: add comprehensive integrations overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,34 @@ IncidentFox is **open source** (Apache 2.0). You can try it instantly in Slack, 
 
 ---
 
+## Integrations
+
+IncidentFox connects to your existing tools and infrastructure. No manual setup required — configure once and it works everywhere.
+
+### Available Now ✅
+
+| Category | Integrations |
+|----------|--------------|
+| **Logs & Metrics** | Coralogix · Grafana · Elasticsearch · Datadog · Prometheus · Jaeger |
+| **Incidents** | incident.io |
+| **Cloud & Infra** | Kubernetes |
+| **Dev Tools** | GitHub · Confluence |
+
+### Coming Soon 🚀
+
+| Category | Integrations |
+|----------|--------------|
+| **Logs & Metrics** | CloudWatch · Splunk · OpenSearch · New Relic · Honeycomb · Dynatrace · Chronosphere · VictoriaMetrics · Kloudfuse · Sentry · Snowflake |
+| **Incidents** | PagerDuty · Opsgenie · ServiceNow |
+| **Cloud & Infra** | AWS · GCP · Azure · Temporal |
+| **Dev Tools** | Jira · Linear · Notion · Glean |
+
+**Need an integration?** [Contact us](mailto:founders@incidentfox.ai) or contribute via [MCP protocol](#under-the-hood) — add new integrations in minutes.
+
+[Full integration docs →](docs/INTEGRATIONS.md)
+
+---
+
 ## Architecture Overview
 
 ```


### PR DESCRIPTION
## Description

Added a new **Integrations** section to the README that provides a clear overview of all supported integrations, organized by category. Lists 10 currently available integrations and 23 coming soon, helping users understand IncidentFox's connectivity at a glance.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- Added "Integrations" section to README after "Why IncidentFox"
- Organized integrations into two tables: "Available Now" and "Coming Soon"
- Grouped integrations by category: Logs & Metrics, Incidents, Cloud & Infra, Dev Tools
- Added call-to-action encouraging users to request integrations or contribute via MCP protocol
- Included link to detailed integration documentation

## Testing

- [x] Manual testing performed (viewed rendered markdown)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Documentation updated (README)
- [x] Branch is up to date with `main`

## Additional Context

This change makes it immediately clear to new users what tools IncidentFox can currently connect to, and what's on the roadmap. Data sourced from `slack-bot/onboarding.py` integration definitions.