### PR TITLE
fix(slack-bot): Add missing _get_internal_headers method

### DIFF
--- a/slack-bot/config_client.py
+++ b/slack-bot/config_client.py
@@ -57,6 +57,13 @@ class ConfigServiceClient:
             "Content-Type": "application/json",
         }
 
+    def _get_internal_headers(self) -> Dict[str, str]:
+        """Get headers for internal service-to-service requests."""
+        return {
+            "X-Internal-Service": "slack-bot",
+            "Content-Type": "application/json",
+        }
+
     def provision_workspace(
         self,
         slack_team_id: str,


### PR DESCRIPTION
## Summary
Fix AttributeError when saving GitHub configuration from Slack modal.

The GitHub installation linking methods (`get_linked_github_installation` and `link_github_installation`) call `_get_internal_headers()` but the method was not defined in `ConfigServiceClient`.

## Error
```
'ConfigServiceClient' object has no attribute '_get_internal_headers'
```

## Fix
Added the missing `_get_internal_headers()` method that returns the `X-Internal-Service` header required by config-service internal API.

## Test plan
- [ ] Deploy slack-bot
- [ ] Try GitHub configuration flow from Slack modal
- [ ] Verify installation links successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)