### PR TITLE
feat(sre-agent): Add sandbox cleanup CronJob to prevent resource exhaustion

### DIFF
--- a/sre-agent/k8s/sandbox-cleanup-cronjob.yaml
+++ b/sre-agent/k8s/sandbox-cleanup-cronjob.yaml
@@ -1,0 +1,120 @@
+# CronJob to clean up expired sandboxes
+# The agent-sandbox controller doesn't enforce TTL (shutdownTime field),
+# so we need this job to prevent resource exhaustion from accumulated sandboxes.
+#
+# Runs every 15 minutes, deletes sandboxes where shutdownTime has passed.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sandbox-cleanup
+  namespace: incidentfox-prod
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sandbox-cleanup
+  namespace: incidentfox-prod
+rules:
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sandbox-cleanup
+  namespace: incidentfox-prod
+subjects:
+  - kind: ServiceAccount
+    name: sandbox-cleanup
+    namespace: incidentfox-prod
+roleRef:
+  kind: Role
+  name: sandbox-cleanup
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sandbox-cleanup
+  namespace: incidentfox-prod
+spec:
+  schedule: "*/15 * * * *"  # Every 15 minutes
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 3600  # Clean up job pods after 1 hour
+      template:
+        spec:
+          serviceAccountName: sandbox-cleanup
+          restartPolicy: OnFailure
+          containers:
+            - name: cleanup
+              image: bitnami/kubectl:latest
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -e
+
+                  echo "=== Sandbox Cleanup Job Started ==="
+                  echo "Current time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+                  # Get current time in seconds since epoch
+                  NOW=$(date +%s)
+
+                  # List all sandboxes with their shutdownTime
+                  echo ""
+                  echo "Checking sandboxes for expired TTL..."
+
+                  DELETED=0
+                  KEPT=0
+
+                  # Get all sandboxes as JSON and process
+                  kubectl get sandbox -n incidentfox-prod -o json | \
+                  jq -r '.items[] | "\(.metadata.name) \(.spec.shutdownTime // "none")"' | \
+                  while read -r NAME SHUTDOWN; do
+                    if [ "$SHUTDOWN" = "none" ] || [ -z "$SHUTDOWN" ]; then
+                      echo "  SKIP: $NAME (no shutdownTime set)"
+                      continue
+                    fi
+
+                    # Convert shutdownTime to seconds since epoch
+                    SHUTDOWN_EPOCH=$(date -d "$SHUTDOWN" +%s 2>/dev/null || echo "0")
+
+                    if [ "$SHUTDOWN_EPOCH" = "0" ]; then
+                      echo "  WARN: $NAME (invalid shutdownTime: $SHUTDOWN)"
+                      continue
+                    fi
+
+                    if [ "$NOW" -gt "$SHUTDOWN_EPOCH" ]; then
+                      echo "  DELETE: $NAME (expired at $SHUTDOWN)"
+                      kubectl delete sandbox "$NAME" -n incidentfox-prod --wait=false || true
+
+                      # Also clean up associated ConfigMap
+                      kubectl delete configmap "envoy-config-$NAME" -n incidentfox-prod --ignore-not-found=true || true
+
+                      DELETED=$((DELETED + 1))
+                    else
+                      REMAINING=$((SHUTDOWN_EPOCH - NOW))
+                      echo "  KEEP: $NAME (expires in ${REMAINING}s)"
+                      KEPT=$((KEPT + 1))
+                    fi
+                  done
+
+                  echo ""
+                  echo "=== Cleanup Complete ==="
+                  echo "Sandboxes remaining: $(kubectl get sandbox -n incidentfox-prod --no-headers 2>/dev/null | wc -l)"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi

--- a/sre-agent/k8s/sandbox-resource-quota.yaml
+++ b/sre-agent/k8s/sandbox-resource-quota.yaml
@@ -1,0 +1,29 @@
+# ResourceQuota to limit sandbox resource consumption
+# Prevents runaway resource exhaustion from accumulated sandboxes
+#
+# Limits:
+# - Max 50 investigation pods (each sandbox creates 1 pod)
+# - Max 100Gi memory total for all sandbox pods
+# - Max 50 CPU cores total for all sandbox pods
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: sandbox-quota
+  namespace: incidentfox-prod
+spec:
+  hard:
+    # Pod count limit - main protection against accumulation
+    count/pods: "100"
+
+    # Memory limits (sandboxes request 512Mi, limit 2Gi each)
+    requests.memory: "50Gi"
+    limits.memory: "150Gi"
+
+    # CPU limits (sandboxes request 100m, limit 2000m each)
+    requests.cpu: "10"
+    limits.cpu: "100"
+
+    # Ephemeral storage (sandboxes request 2Gi, limit 10Gi each)
+    requests.ephemeral-storage: "100Gi"
+    limits.ephemeral-storage: "500Gi"


### PR DESCRIPTION
## Summary

- Adds a CronJob that runs every 15 minutes to clean up expired sandboxes
- Adds an optional ResourceQuota manifest for additional protection
- Fixes root cause of cluster resource exhaustion from accumulated sandboxes

## Problem

The `agent-sandbox` controller doesn't enforce the `shutdownTime` TTL field in the Sandbox CRD. This caused:
- 70+ stale sandboxes to accumulate over time
- Nodes running out of memory
- Cluster autoscaler not reacting (it only responds to Pending pods, not resource pressure)

## Solution

| File | Description |
|------|-------------|
| `sandbox-cleanup-cronjob.yaml` | CronJob that deletes sandboxes where `shutdownTime` has passed |
| `sandbox-resource-quota.yaml` | Optional quota to limit total sandbox resources (not deployed) |

## Deployment

The CronJob has already been deployed to `incidentfox-prod` and is working:

```
kubectl apply -f sre-agent/k8s/sandbox-cleanup-cronjob.yaml
```

## Test plan

- [x] CronJob deployed and tested manually
- [x] Verified expired sandbox was deleted
- [x] Verified active sandboxes were preserved
- [x] Cluster now healthy with 11 sandboxes (down from 80+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)