### PR TITLE
feat(credential-proxy): Add full Honeycomb integration support

### DIFF
--- a/sre-agent/credential-proxy/src/credential_resolver/domain_mapping.py
+++ b/sre-agent/credential-proxy/src/credential_resolver/domain_mapping.py
@@ -18,6 +18,9 @@ DOMAIN_TO_INTEGRATION: dict[str, str] = {
     "api.ap3.coralogix.com": "coralogix",
     # Confluence (Atlassian Cloud)
     "atlassian.net": "confluence",
+    # Honeycomb (US and EU regions)
+    "api.honeycomb.io": "honeycomb",
+    "api.eu1.honeycomb.io": "honeycomb",
 }
 
 # Path prefixes for proxy mode (when host is envoy:8001, localhost:8001, etc.)
@@ -26,6 +29,7 @@ PATH_TO_INTEGRATION: dict[str, str] = {
     "/api/event_logging/": "anthropic",  # Anthropic telemetry
     "/api/v1/dataprime/": "coralogix",  # Coralogix DataPrime
     "/api/v1/query": "coralogix",  # Coralogix query
+    "/honeycomb/": "honeycomb",  # Honeycomb API
 }
 
 # Hosts that use path-based routing (static list)


### PR DESCRIPTION
## Description

Add complete Honeycomb integration support to the credential proxy, enabling the proxy to route and authenticate Honeycomb API requests.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Related Issues

Follow-up to #276 (Honeycomb observability integration)

## Changes Made

**domain_mapping.py:**
- Add `api.honeycomb.io` and `api.eu1.honeycomb.io` to `DOMAIN_TO_INTEGRATION`
- Add `/honeycomb/` path prefix to `PATH_TO_INTEGRATION` for proxy mode

**main.py:**
- Add Honeycomb to `load_env_credentials()` (HONEYCOMB_API_KEY, HONEYCOMB_DOMAIN)
- Add "honeycomb" to `ACTIVE_INTEGRATIONS` list
- Add `is_integration_configured()` check for Honeycomb (api_key required)
- Add `get_integration_metadata()` for Honeycomb (returns URL)
- Add `/honeycomb/{path:path}` proxy endpoint
- Add `build_auth_headers()` for Honeycomb (X-Honeycomb-Team header)

## Testing

### Test Plan

- [x] Manual testing performed

### Testing Steps

1. Verified domain mapping matches honeycomb_client.py proxy paths
2. Confirmed X-Honeycomb-Team header is correct auth method
3. Verified proxy endpoint follows existing patterns

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] No new warnings introduced
- [x] Branch is up to date with `main`

## Deployment Notes

- [x] Requires environment variable updates (optional: HONEYCOMB_API_KEY, HONEYCOMB_DOMAIN)
- [x] Backward compatible