### PR TITLE
feat(credential-proxy): add env var loading for all backends

### DIFF
--- a/sre-agent/credential-proxy/src/credential_resolver/main.py
+++ b/sre-agent/credential-proxy/src/credential_resolver/main.py
@@ -145,13 +145,21 @@ async def lifespan(app: FastAPI):
                         f"  {integration}: api_key={mask_secret(creds.get('api_key'))}, "
                         f"app_key={mask_secret(creds.get('app_key'))}, site={creds.get('site')}"
                     )
-                elif integration in ["confluence", "grafana", "elasticsearch", "prometheus", "jaeger"]:
+                elif integration in [
+                    "confluence",
+                    "grafana",
+                    "elasticsearch",
+                    "prometheus",
+                    "jaeger",
+                ]:
                     logger.info(
                         f"  {integration}: domain={creds.get('domain') or '(not set)'}, "
                         f"api_key={mask_secret(creds.get('api_key'))}"
                     )
                 else:
-                    logger.info(f"  {integration}: api_key={mask_secret(creds.get('api_key'))}")
+                    logger.info(
+                        f"  {integration}: api_key={mask_secret(creds.get('api_key'))}"
+                    )
 
     yield
 


### PR DESCRIPTION
## Summary

- Adds environment variable loading for all observability backends in self-hosted/local mode
- Closes and replaces #260 (which was outdated/had conflicts)

### New Env Vars Supported

| Integration | Environment Variables |
|-------------|----------------------|
| **Datadog** | `DD_API_KEY`, `DD_APP_KEY`, `DD_SITE` |
| **Elasticsearch** | `ELASTICSEARCH_URL`, `ELASTICSEARCH_API_KEY`, `ELASTICSEARCH_USER` |
| **Grafana** | `GRAFANA_URL`, `GRAFANA_API_KEY` |
| **Prometheus** | `PROMETHEUS_URL`, `PROMETHEUS_TOKEN` |
| **Jaeger** | `JAEGER_URL`, `JAEGER_TOKEN` |
| **GitHub** | `GITHUB_TOKEN`, `GITHUB_ENTERPRISE_URL` |
| **Honeycomb** | `HONEYCOMB_API_KEY`, `HONEYCOMB_DATASET` |

### Why This PR Instead of #260

PR #260 added domain mappings for ext_authz pattern, but the codebase already has **reverse proxy endpoints** (`/grafana/{path}`, etc.) that handle customer-specific URLs. The main missing piece was env var loading for self-hosted mode, which this PR addresses.

## Test plan

- [ ] Deploy locally with `CREDENTIAL_SOURCE=environment`
- [ ] Verify each integration's env vars are loaded correctly on startup (check logs)
- [ ] Test Datadog proxy with `DD_API_KEY` + `DD_APP_KEY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)