### PR TITLE
feat(helm): Add sandbox router, cleanup, and RBAC templates

### DIFF
--- a/charts/incidentfox/templates/sandbox-cleanup.yaml
+++ b/charts/incidentfox/templates/sandbox-cleanup.yaml
@@ -1,0 +1,132 @@
+{{- if and .Values.services.agent.enabled .Values.services.agent.sandbox.enabled .Values.services.sandboxCleanup.enabled }}
+---
+# Sandbox Cleanup - CronJob that removes expired sandbox pods
+# Runs periodically to clean up sandboxes that have exceeded their TTL.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-sandbox-cleanup
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: sandbox-cleanup
+    app.kubernetes.io/name: sandbox-cleanup
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-sandbox-cleanup
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: sandbox-cleanup
+    app.kubernetes.io/name: sandbox-cleanup
+    app.kubernetes.io/instance: {{ .Release.Name }}
+rules:
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-sandbox-cleanup
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: sandbox-cleanup
+    app.kubernetes.io/name: sandbox-cleanup
+    app.kubernetes.io/instance: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-sandbox-cleanup
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-sandbox-cleanup
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-sandbox-cleanup
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: sandbox-cleanup
+    app.kubernetes.io/name: sandbox-cleanup
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  schedule: {{ .Values.services.sandboxCleanup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.services.sandboxCleanup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.services.sandboxCleanup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: {{ .Values.services.sandboxCleanup.ttlSecondsAfterFinished }}
+      template:
+        spec:
+          serviceAccountName: {{ .Release.Name }}-sandbox-cleanup
+          restartPolicy: OnFailure
+          containers:
+            - name: cleanup
+              image: {{ .Values.services.sandboxCleanup.image }}
+              resources:
+                {{- toYaml .Values.services.sandboxCleanup.resources | nindent 16 }}
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -e
+
+                  echo "=== Sandbox Cleanup Job Started ==="
+                  echo "Current time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  echo "Namespace: {{ .Values.namespace }}"
+
+                  # Get current time in seconds since epoch
+                  NOW=$(date +%s)
+
+                  echo ""
+                  echo "Checking sandboxes for expired TTL..."
+
+                  DELETED=0
+                  KEPT=0
+
+                  # Get all sandboxes as JSON and process
+                  kubectl get sandbox -n {{ .Values.namespace }} -o json | \
+                  jq -r '.items[] | "\(.metadata.name) \(.spec.shutdownTime // "none")"' | \
+                  while read -r NAME SHUTDOWN; do
+                    if [ "$SHUTDOWN" = "none" ] || [ -z "$SHUTDOWN" ]; then
+                      echo "  SKIP: $NAME (no shutdownTime set)"
+                      continue
+                    fi
+
+                    # Convert shutdownTime to seconds since epoch
+                    SHUTDOWN_EPOCH=$(date -d "$SHUTDOWN" +%s 2>/dev/null || echo "0")
+
+                    if [ "$SHUTDOWN_EPOCH" = "0" ]; then
+                      echo "  WARN: $NAME (invalid shutdownTime: $SHUTDOWN)"
+                      continue
+                    fi
+
+                    if [ "$NOW" -gt "$SHUTDOWN_EPOCH" ]; then
+                      echo "  DELETE: $NAME (expired at $SHUTDOWN)"
+                      kubectl delete sandbox "$NAME" -n {{ .Values.namespace }} --wait=false || true
+
+                      # Also clean up associated ConfigMap
+                      kubectl delete configmap "envoy-config-$NAME" -n {{ .Values.namespace }} --ignore-not-found=true || true
+
+                      DELETED=$((DELETED + 1))
+                    else
+                      REMAINING=$((SHUTDOWN_EPOCH - NOW))
+                      echo "  KEEP: $NAME (expires in ${REMAINING}s)"
+                      KEPT=$((KEPT + 1))
+                    fi
+                  done
+
+                  echo ""
+                  echo "=== Cleanup Complete ==="
+                  echo "Sandboxes remaining: $(kubectl get sandbox -n {{ .Values.namespace }} --no-headers 2>/dev/null | wc -l)"
+{{- end }}

--- a/charts/incidentfox/templates/sandbox-rbac.yaml
+++ b/charts/incidentfox/templates/sandbox-rbac.yaml
@@ -1,0 +1,126 @@
+{{- if and .Values.services.agent.enabled .Values.services.agent.sandbox.enabled }}
+---
+# Sandbox Controller RBAC - ClusterRoles for managing Sandbox CRDs
+# These roles allow the agent to create/manage sandboxes and their associated resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-sandbox-controller
+  labels:
+    app: incidentfox-agent
+    app.kubernetes.io/name: sandbox-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  # Core resources needed for sandbox pods
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims", "pods", "services"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # Sandbox CRD management
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes/status"]
+    verbs: ["get", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-sandbox-controller-extensions
+  labels:
+    app: incidentfox-agent
+    app.kubernetes.io/name: sandbox-controller-extensions
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  # Pod management for sandbox pools
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # Sandbox CRD management
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # Sandbox extensions (warm pools, claims, templates)
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxclaims", "sandboxwarmpools"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxclaims/status", "sandboxwarmpools/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxtemplates"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-sandbox-service-patcher
+  labels:
+    app: incidentfox-agent
+    app.kubernetes.io/name: sandbox-service-patcher
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  # Allow patching services for sandbox routing
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "patch", "update"]
+  # ConfigMap management for Envoy configs
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+# Bind the sandbox controller role to the agent service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-sandbox-controller
+  labels:
+    app: incidentfox-agent
+    app.kubernetes.io/name: sandbox-controller
+    app.kubernetes.io/instance: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.services.agent.serviceAccount.name }}
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-sandbox-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-sandbox-controller-extensions
+  labels:
+    app: incidentfox-agent
+    app.kubernetes.io/name: sandbox-controller-extensions
+    app.kubernetes.io/instance: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.services.agent.serviceAccount.name }}
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-sandbox-controller-extensions
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-sandbox-service-patcher
+  labels:
+    app: incidentfox-agent
+    app.kubernetes.io/name: sandbox-service-patcher
+    app.kubernetes.io/instance: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.services.agent.serviceAccount.name }}
+    namespace: {{ .Values.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-sandbox-service-patcher
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/incidentfox/templates/sandbox-router.yaml
+++ b/charts/incidentfox/templates/sandbox-router.yaml
@@ -1,0 +1,115 @@
+{{- if and .Values.services.agent.enabled .Values.services.agent.sandbox.enabled .Values.services.sandboxRouter.enabled }}
+---
+# Sandbox Router - Routes requests to dynamically created sandbox pods
+# The router provides stable endpoints for sandbox access while pods come and go.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-sandbox-router
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: sandbox-router
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.services.sandboxRouter.replicas }}
+  selector:
+    matchLabels:
+      app: sandbox-router
+  template:
+    metadata:
+      labels:
+        app: sandbox-router
+        app.kubernetes.io/name: sandbox-router
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: sandbox-router
+      containers:
+        - name: router
+          image: {{ .Values.services.sandboxRouter.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - containerPort: {{ .Values.services.sandboxRouter.servicePort }}
+              protocol: TCP
+          env:
+            - name: SANDBOX_NAMESPACE
+              value: {{ .Values.services.agent.sandbox.namespace | default .Values.namespace | quote }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.services.sandboxRouter.servicePort }}
+            initialDelaySeconds: {{ .Values.services.sandboxRouter.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.services.sandboxRouter.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.services.sandboxRouter.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.services.sandboxRouter.readinessProbe.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.services.sandboxRouter.servicePort }}
+            initialDelaySeconds: {{ .Values.services.sandboxRouter.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.services.sandboxRouter.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.services.sandboxRouter.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.services.sandboxRouter.livenessProbe.failureThreshold }}
+          resources:
+            {{- toYaml .Values.services.sandboxRouter.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-sandbox-router
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: sandbox-router
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  selector:
+    app: sandbox-router
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.services.sandboxRouter.servicePort }}
+      targetPort: {{ .Values.services.sandboxRouter.servicePort }}
+---
+{{- if .Values.services.sandboxRouter.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-sandbox-router
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: sandbox-router
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-sandbox-router
+  minReplicas: {{ .Values.services.sandboxRouter.hpa.minReplicas }}
+  maxReplicas: {{ .Values.services.sandboxRouter.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.services.sandboxRouter.hpa.targetCPUUtilizationPercentage }}
+{{- end }}
+{{- end }}

--- a/charts/incidentfox/values.prod.yaml
+++ b/charts/incidentfox/values.prod.yaml
@@ -192,6 +192,23 @@ services:
       otlp:
         enabled: false
 
+  # Sandbox Router for routing to sandbox pods
+  sandboxRouter:
+    enabled: true
+    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-sandbox-router:latest"
+    replicas: 2
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 70
+
+  # Sandbox Cleanup for expired sandbox garbage collection
+  sandboxCleanup:
+    enabled: true
+    image: "bitnami/kubectl:latest"
+    schedule: "*/15 * * * *"
+
   # Credential Resolver for sandbox credential injection
   credentialResolver:
     enabled: true

--- a/charts/incidentfox/values.staging.yaml
+++ b/charts/incidentfox/values.staging.yaml
@@ -200,6 +200,23 @@ services:
       otlp:
         enabled: false
 
+  # Sandbox Router for routing to sandbox pods
+  sandboxRouter:
+    enabled: true
+    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-sandbox-router:staging"
+    replicas: 2
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 70
+
+  # Sandbox Cleanup for expired sandbox garbage collection
+  sandboxCleanup:
+    enabled: true
+    image: "bitnami/kubectl:latest"
+    schedule: "*/15 * * * *"
+
   # Credential Resolver for sandbox credential injection
   credentialResolver:
     enabled: true

--- a/charts/incidentfox/values.yaml
+++ b/charts/incidentfox/values.yaml
@@ -616,6 +616,53 @@ services:
       maxReplicas: 6
       targetCPUUtilizationPercentage: 70
 
+  # Sandbox Router - Routes requests to dynamically created sandbox pods
+  # Provides stable endpoints while sandbox pods are created/destroyed.
+  sandboxRouter:
+    enabled: false  # Enable when using gVisor sandboxes
+    image: "incidentfox/sandbox-router:v1.0.0"
+    replicas: 2
+    servicePort: 8080
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "512Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"
+    readinessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 3
+    livenessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+    hpa:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 70
+
+  # Sandbox Cleanup - CronJob that removes expired sandbox pods
+  # Runs periodically to garbage collect sandboxes past their TTL.
+  sandboxCleanup:
+    enabled: false  # Enable when using gVisor sandboxes
+    image: "bitnami/kubectl:latest"
+    schedule: "*/15 * * * *"  # Every 15 minutes
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    ttlSecondsAfterFinished: 3600
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
+      limits:
+        cpu: "200m"
+        memory: "128Mi"
+
   # Credential Resolver - JWT-secured credential injection for sandbox pods
   # This service validates sandbox JWTs and injects credentials via Envoy ext_authz.
   # Sandboxes cannot access credentials directly - enhances security.


### PR DESCRIPTION
## Summary

Completes the Helm chart for unified-agent sandbox isolation by adding three missing templates and updating values files. These components are already running manually in production (incidentfox-prod) and are now ready for Helm management.

## Changes Made

- **sandbox-router.yaml**: Deployment + Service + HPA for routing to dynamically created sandbox pods
- **sandbox-cleanup.yaml**: CronJob + ServiceAccount + Role + RoleBinding for garbage collecting expired sandboxes  
- **sandbox-rbac.yaml**: Three ClusterRoles + ClusterRoleBindings enabling the agent to manage Sandbox CRDs
- **values files**: Enabled sandbox components in both staging and production environments

## Deployment Notes

- Sandbox router and cleanup are disabled by default in values.yaml
- Both enabled in values.staging.yaml (incidentfox-demo cluster) 
- Both enabled in values.prod.yaml (incidentfox-prod cluster)
- Helm chart is now complete for unified-agent architecture from PR #281

## Verification

Templates validated with `helm lint` and `helm template` - all render correctly with both staging and production values files.