### PR TITLE
feat(sandbox): Pass Langfuse credentials to sandbox pods for tracing

### DIFF
--- a/sre-agent/sandbox_manager.py
+++ b/sre-agent/sandbox_manager.py
@@ -609,6 +609,31 @@ static_resources:
                                         "name": "DISABLE_LAMINAR",
                                         "value": "true",
                                     },
+                                    # Langfuse observability (optional)
+                                    {
+                                        "name": "LANGFUSE_PUBLIC_KEY",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "name": "incidentfox-langfuse",
+                                                "key": "LANGFUSE_PUBLIC_KEY",
+                                                "optional": True,
+                                            }
+                                        },
+                                    },
+                                    {
+                                        "name": "LANGFUSE_SECRET_KEY",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "name": "incidentfox-langfuse",
+                                                "key": "LANGFUSE_SECRET_KEY",
+                                                "optional": True,
+                                            }
+                                        },
+                                    },
+                                    {
+                                        "name": "LANGFUSE_HOST",
+                                        "value": os.getenv("LANGFUSE_HOST", "https://us.cloud.langfuse.com"),
+                                    },
                                     # Kubernetes context (use pre-configured kubeconfig for incidentfox-demo cluster)
                                     {
                                         "name": "KUBECONFIG",

--- a/unified-agent/src/unified_agent/sandbox/manager.py
+++ b/unified-agent/src/unified_agent/sandbox/manager.py
@@ -491,6 +491,31 @@ static_resources:
                         }
                     },
                 },
+                # Langfuse observability (optional)
+                {
+                    "name": "LANGFUSE_PUBLIC_KEY",
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": "incidentfox-langfuse",
+                            "key": "LANGFUSE_PUBLIC_KEY",
+                            "optional": True,
+                        }
+                    },
+                },
+                {
+                    "name": "LANGFUSE_SECRET_KEY",
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": "incidentfox-langfuse",
+                            "key": "LANGFUSE_SECRET_KEY",
+                            "optional": True,
+                        }
+                    },
+                },
+                {
+                    "name": "LANGFUSE_HOST",
+                    "value": os.getenv("LANGFUSE_HOST", "https://us.cloud.langfuse.com"),
+                },
             ]
         )
 


### PR DESCRIPTION
## Description

Sandbox pods now receive Langfuse environment variables for LLM call tracing. Previously, only the agent pod had Langfuse credentials, but the sandbox pods (where actual LLM calls happen) did not.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Add `LANGFUSE_PUBLIC_KEY` env var to sandbox pods (from `incidentfox-langfuse` secret)
- Add `LANGFUSE_SECRET_KEY` env var to sandbox pods (from `incidentfox-langfuse` secret)  
- Add `LANGFUSE_HOST` env var to sandbox pods (passed from agent pod environment)
- Changes applied to both `unified-agent` and `sre-agent` sandbox managers

## Testing

### Test Plan

- [x] Manual testing performed
- [x] Tested in Kubernetes environment

### Testing Steps

1. Deploy to staging
2. Trigger Slack bot interaction
3. Verify traces appear in Langfuse dashboard at https://us.cloud.langfuse.com

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] No new warnings introduced
- [x] Backward compatible (secrets are optional)

## Deployment Notes

- [x] Requires new secrets/credentials (`incidentfox-langfuse` secret must exist in namespace)
- [x] Backward compatible (env vars are optional, won't break if secret doesn't exist)