### PR TITLE
fix(helm): Safe check for encryptionKey config in external-secrets

### DIFF
--- a/charts/incidentfox/templates/external-secrets.yaml
+++ b/charts/incidentfox/templates/external-secrets.yaml
@@ -409,7 +409,7 @@ spec:
         key: {{ $c.slackBot.signingSecretRemoteRefKey | quote }}
 {{- end }}
 
-{{- if $c.encryptionKey.enabled }}
+{{- if and $c.encryptionKey $c.encryptionKey.enabled }}
 ---
 # Encryption key for config-service column encryption
 apiVersion: {{ $apiVersion }}


### PR DESCRIPTION
## Description

Fix nil pointer error when `encryptionKey` config is not defined in values file.

## Problem

The GHA deploy workflow failed with:
```
Error: UPGRADE FAILED: template: incidentfox/templates/external-secrets.yaml:412:9: 
  nil pointer evaluating interface {}.enabled
```

This happened because `values.prod.yaml` doesn't have the `encryptionKey` config that was added for staging.

## Fix

Changed the template check from:
```yaml
{{- if $c.encryptionKey.enabled }}
```
to:
```yaml
{{- if and $c.encryptionKey $c.encryptionKey.enabled }}
```

This safely checks if the config exists before accessing its properties.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] Backward compatible
- [x] No new warnings