### PR TITLE
fix(cluster): Fix gVisor containerd runtime config for EKS

### DIFF
--- a/sre-agent/k8s/aws/gvisor-installer.yaml
+++ b/sre-agent/k8s/aws/gvisor-installer.yaml
@@ -63,16 +63,21 @@ spec:
           mkdir -p /host/etc/containerd
 
           # Remove any old/wrong gVisor runtime config (both old and new CRI paths)
-          sed -i '/\[plugins\..*containerd\.runtimes\.runsc\]/,+2d' /host/etc/containerd/config.toml 2>/dev/null || true
+          sed -i '/\[plugins\..*containerd\.runtimes\.runsc\]/,/^\[/{ /^\[plugins/!d; /runtimes\.runsc/d; }' /host/etc/containerd/config.toml 2>/dev/null || true
+          # Also remove the old grpc.v1.cri format completely
+          sed -i '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\.containerd\.runtimes\.runsc\]/,/^\[/d' /host/etc/containerd/config.toml 2>/dev/null || true
 
-          # Add gVisor runtime config (must match EKS containerd format - uses grpc.v1.cri path)
-          if ! grep -q 'containerd.runtimes.runsc' /host/etc/containerd/config.toml 2>/dev/null; then
-            echo "Adding gVisor runtime configuration..."
+          # Add gVisor runtime config (must match EKS containerd v3 format - uses cri.v1.runtime path)
+          if ! grep -q "io.containerd.cri.v1.runtime.*runtimes.runsc" /host/etc/containerd/config.toml 2>/dev/null; then
+            echo "Adding gVisor runtime configuration (containerd v3 format)..."
             echo '' >> /host/etc/containerd/config.toml
-            echo '[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]' >> /host/etc/containerd/config.toml
+            echo "[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runsc]" >> /host/etc/containerd/config.toml
             echo 'runtime_type = "io.containerd.runsc.v1"' >> /host/etc/containerd/config.toml
+            echo '' >> /host/etc/containerd/config.toml
+            echo "[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runsc.options]" >> /host/etc/containerd/config.toml
+            echo 'TypeUrl = "io.containerd.runsc.v1.options"' >> /host/etc/containerd/config.toml
           else
-            echo "✅ containerd already configured for gVisor"
+            echo "✅ containerd already configured for gVisor (v3 format)"
           fi
           
           # Restart containerd using nsenter


### PR DESCRIPTION
## Description

Fixed gVisor integration in production cluster. The gVisor installer was using an outdated containerd plugin path that's incompatible with EKS containerd v2.1.5, causing investigation pods to fail with "no runtime for runsc is configured" errors.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Updated gVisor installer to use correct containerd v3 format (`io.containerd.cri.v1.runtime` instead of `io.containerd.grpc.v1.cri`)
- Improved sed patterns to properly remove old conflicting configurations
- Added runtime options section for proper gVisor configuration

## Testing

- [x] Tested in Kubernetes environment (incidentfox-prod)
- Investigation pods now start successfully with 2/2 containers ready
- sandbox-router can reach investigation pods without 502 errors

## Deployment Notes

- [x] Backward compatible
- No database migrations or config changes required
- DaemonSet auto-applies fix to all cluster nodes on next rollout