### PR TITLE
fix(staging): Fix image tags and secret paths for staging deployment

### DIFF
--- a/charts/incidentfox/values.staging.yaml
+++ b/charts/incidentfox/values.staging.yaml
@@ -55,14 +55,14 @@ externalSecrets:
       adminTokenKey: ADMIN_TOKEN
       tokenPepperKey: TOKEN_PEPPER
       impersonationJwtSecretKey: IMPERSONATION_JWT_SECRET
-      adminTokenRemoteRefKey: incidentfox/staging/config_service_admin_token
-      tokenPepperRemoteRefKey: incidentfox/staging/config_service_token_pepper
-      impersonationJwtSecretRemoteRefKey: incidentfox/staging/config_service_impersonation_jwt_secret
+      adminTokenRemoteRefKey: incidentfox-config-service/admin_token
+      tokenPepperRemoteRefKey: incidentfox-config-service/token_pepper
+      impersonationJwtSecretRemoteRefKey: incidentfox-config-service/impersonation_jwt_secret
     agentOpenAI:
       enabled: true
       secretName: incidentfox-openai
       apiKeyKey: api_key
-      apiKeyRemoteRefKey: incidentfox/staging/openai_api_key
+      apiKeyRemoteRefKey: incidentfox/prod/openai_api_key  # Using prod key for staging
     webUiOidc:
       enabled: false
     slack:
@@ -71,7 +71,7 @@ externalSecrets:
       signingSecretKey: signing_secret
       botTokenKey: bot_token
       signingSecretRemoteRefKey: incidentfox/staging/slack_signing_secret
-      botTokenRemoteRefKey: incidentfox/staging/slack_bot_token
+      botTokenRemoteRefKey: incidentfox/prod/slack_bot_token  # Using prod token for staging
     github:
       enabled: true
       secretName: incidentfox-github
@@ -91,7 +91,7 @@ externalSecrets:
       enabled: true
       secretName: incidentfox-orchestrator-internal
       internalTokenKey: internal_token
-      internalTokenRemoteRefKey: incidentfox/staging/orchestrator_internal_token
+      internalTokenRemoteRefKey: incidentfox/prod/orchestrator_internal_token  # Using prod token for staging
     langfuse:
       enabled: true
       secretName: incidentfox-langfuse
@@ -131,7 +131,7 @@ externalSecrets:
 services:
   configService:
     enabled: true
-    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-config-service:staging"
+    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-config-service:latest"
     adminAuthMode: token
     teamAuthMode: token
     resources:
@@ -158,7 +158,7 @@ services:
 
   orchestrator:
     enabled: true
-    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-orchestrator:staging"
+    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-orchestrator:latest"
     requireAdminStar: true
     slackAgentMaxTurns: "200"
     slackAgentTimeoutSeconds: "180"
@@ -166,7 +166,7 @@ services:
   # Slack Bot - Multi-tenant Slack integration
   slackBot:
     enabled: true
-    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-slack-bot:staging"
+    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-slack-bot:latest"
     replicas: 1
     servicePort: 3000
     baseUrl: "https://slack-staging.incidentfox.ai"  # OAuth redirect base URL (staging)
@@ -252,7 +252,7 @@ services:
   # Ultimate RAG - Knowledge base with graph queries, teaching, analytics
   ultimateRag:
     enabled: true
-    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-ultimate-rag:staging"
+    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-ultimate-rag:latest"
     replicas: 1
     serviceAccountRoleArn: "arn:aws:iam::103002841599:role/incidentfox-raptor-kb-role"
     defaultTree: "mega_ultra_v2"
@@ -268,7 +268,7 @@ services:
 
   webUi:
     enabled: true
-    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-web-ui:staging"
+    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-web-ui:latest"
     cookieSecure: true
     raptorApiUrl: "http://incidentfox-rag.incidentfox.svc.cluster.local:8000"
     oidc:
@@ -282,6 +282,6 @@ services:
   # K8s Gateway for SaaS mode (customer K8s agents)
   k8sGateway:
     enabled: true
-    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-k8s-gateway:staging"
+    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-k8s-gateway:latest"
     replicas: 2
     logLevel: "INFO"


### PR DESCRIPTION
## Summary

- Change all image tags from `:staging` to `:latest` (GHA only pushes `:latest`)
- Fix config-service secret paths to use existing AWS Secrets Manager paths
- Use prod secrets for staging where staging-specific secrets don't exist

## Changes

### Image Tags
All services now use `:latest` tag instead of `:staging` because the GHA workflow only pushes `:latest` and `:<sha>` tags.

### Secret Path Fixes
| Secret | Old Path | New Path |
|--------|----------|----------|
| config-service admin_token | `incidentfox/staging/config_service_admin_token` | `incidentfox-config-service/admin_token` |
| config-service token_pepper | `incidentfox/staging/config_service_token_pepper` | `incidentfox-config-service/token_pepper` |
| config-service impersonation_jwt | `incidentfox/staging/config_service_impersonation_jwt_secret` | `incidentfox-config-service/impersonation_jwt_secret` |
| openai api_key | `incidentfox/staging/openai_api_key` | `incidentfox/prod/openai_api_key` |
| orchestrator internal_token | `incidentfox/staging/orchestrator_internal_token` | `incidentfox/prod/orchestrator_internal_token` |
| slack bot_token | `incidentfox/staging/slack_bot_token` | `incidentfox/prod/slack_bot_token` |

## Test Plan

- [x] Deployed to staging manually - all pods running
- [x] ExternalSecrets all synced successfully
- [ ] Verify Slack bot works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)