### PR TITLE
fix(helm): Add credential-resolver-svc static service name

### DIFF
--- a/charts/incidentfox/templates/credential-resolver.yaml
+++ b/charts/incidentfox/templates/credential-resolver.yaml
@@ -141,4 +141,24 @@ spec:
       port: {{ .Values.services.credentialResolver.servicePort | default 8002 }}
       targetPort: {{ .Values.services.credentialResolver.servicePort | default 8002 }}
       protocol: TCP
+---
+# Static service name expected by sandbox Envoy configs
+# The SandboxManager generates Envoy configs that call credential-resolver-svc
+apiVersion: v1
+kind: Service
+metadata:
+  name: credential-resolver-svc
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: incidentfox-credential-resolver
+    component: security
+spec:
+  type: ClusterIP
+  selector:
+    app: incidentfox-credential-resolver
+  ports:
+    - name: http
+      port: 8002
+      targetPort: {{ .Values.services.credentialResolver.servicePort | default 8002 }}
+      protocol: TCP
 {{- end }}


### PR DESCRIPTION
## Summary
- Add static `credential-resolver-svc` service to match what sandbox Envoy configs expect
- Follows the same pattern as `sandbox-router-svc` fix in PR #294

## Root Cause
The SandboxManager generates per-sandbox Envoy configs that reference:
```
http://credential-resolver-svc.{namespace}.svc.cluster.local:8002/check
```

But the Helm template only creates `incidentfox-credential-resolver` service.

This caused 403 errors because sandbox pods couldn't inject credentials - Envoy's ext_authz filter failed to resolve the DNS.

## Fix
Added a second service `credential-resolver-svc` that points to the same credential-resolver pods.

## Test plan
- [x] Manually created the service in staging cluster - verified API calls work
- [x] Verified Anthropic API returns 200 through Envoy proxy
- [ ] Deploy via Helm to staging
- [ ] Verify Slack bot works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)