### PR TITLE
feat(slack-bot): Add channel-based team routing

### DIFF
--- a/slack-bot/app.py
+++ b/slack-bot/app.py
@@ -2516,9 +2516,13 @@ def handle_message(event, client, context):
             team_token = None
             try:
                 config_client = get_config_client()
-                team_token = config_client.get_team_token_for_channel(team_id, channel_id)
+                team_token = config_client.get_team_token_for_channel(
+                    team_id, channel_id
+                )
             except Exception as e:
-                logger.warning(f"Failed to get team token for {team_id}/{channel_id}: {e}")
+                logger.warning(
+                    f"Failed to get team token for {team_id}/{channel_id}: {e}"
+                )
 
             # Build request payload
             request_payload = {

--- a/slack-bot/config_client.py
+++ b/slack-bot/config_client.py
@@ -337,9 +337,7 @@ class ConfigServiceClient:
             token_response = self._issue_team_token(org_id, team_node_id)
             token = token_response.get("token")
             if token:
-                logger.debug(
-                    f"Issued team token for org={org_id}, team={team_node_id}"
-                )
+                logger.debug(f"Issued team token for org={org_id}, team={team_node_id}")
                 return token
             return None
         except requests.exceptions.HTTPError as e:


### PR DESCRIPTION
## Summary
- Add `lookup_routing()` method to slack-bot's ConfigServiceClient that calls config service's internal routing API
- Add `get_team_token_for_channel()` method that tries channel routing first, falls back to workspace-based routing
- Update all 5 investigation handlers to use channel-based routing

## Why
Currently slack-bot routes all messages in a workspace to a single "default" team. This enables different Slack channels to be mapped to different teams within the same workspace.

## How it works
```
Message in #weirwood-demo channel
    ↓
slack-bot calls lookup_routing("C0ADSDTFF41")
    ↓
config service finds team with routing.slack_channel_ids containing "C0ADSDTFF41"
    ↓
Returns org_id="incidentfox-demo", team_node_id="weirwood-demo"
    ↓
Agent runs with that team's config
```

If no channel mapping exists, falls back to current workspace-based routing (`slack-{team_id}` / `default`).

## Test plan
- [ ] Deploy to demo environment
- [ ] Send message in #weirwood-demo channel (which has channel routing configured)
- [ ] Verify it routes to weirwood-demo team config
- [ ] Send message in other channel (no routing configured)
- [ ] Verify it falls back to default team

🤖 Generated with [Claude Code](https://claude.com/claude-code)