### PR TITLE
fix(deploy): Adopt static service names for Helm ownership

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -220,6 +220,11 @@ jobs:
             kubectl delete deployment "$RESOURCE_NAME" -n "$NS" --wait=false
           fi
 
+          # Adopt static service names that may have been created manually
+          # These are required by hardcoded Envoy configs in sandbox pods
+          patch_resource service "sandbox-router-svc"
+          patch_resource service "credential-resolver-svc"
+
       - name: Deploy with Helm (no wait)
         working-directory: charts
         run: |


### PR DESCRIPTION
## Summary
- Add `sandbox-router-svc` and `credential-resolver-svc` to the Helm adoption step
- These services were created by previous PRs (#294, #296) but lack Helm ownership annotations
- Without this fix, Helm refuses to manage them and deployment fails

## Context
The GHA deploy failed with:
```
Error: UPGRADE FAILED: Service "credential-resolver-svc" in namespace "incidentfox" exists and cannot be imported
```

This PR fixes the adoption step to patch these services with Helm ownership metadata before deployment.

## Test plan
- [ ] Merge PR
- [ ] Re-run GHA Deploy to EKS workflow
- [ ] Verify deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)