### PR TITLE
fix(deploy): Wait for slack-bot service deletion before Helm upgrade

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -242,10 +242,17 @@ jobs:
 
           # Delete LoadBalancer services with immutable fields (loadBalancerClass)
           # These must be recreated by Helm with the correct spec
+          # IMPORTANT: Must wait for deletion to complete before Helm upgrade
           for svc in incidentfox-slack-bot; do
             if kubectl get service "$svc" -n "$NS" &>/dev/null; then
               echo "Deleting service/$svc (loadBalancerClass is immutable, Helm will recreate)..."
-              kubectl delete service "$svc" -n "$NS" --wait=false
+              kubectl delete service "$svc" -n "$NS" --wait=true --timeout=60s
+              # Extra verification that service is gone
+              while kubectl get service "$svc" -n "$NS" &>/dev/null; do
+                echo "Waiting for service/$svc to be fully deleted..."
+                sleep 2
+              done
+              echo "service/$svc deleted successfully"
             fi
           done
 


### PR DESCRIPTION
## Summary
- Fixed race condition where Helm tried to update slack-bot service while it was still being deleted
- Changed `--wait=false` to `--wait=true --timeout=60s`
- Added verification loop to ensure service is fully deleted before proceeding

## Context
Previous deploy failed because the service deletion returned immediately but Helm started ~10ms later, hitting the immutable `loadBalancerClass` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)