### PR TITLE
fix(helm): Extract api_key from JSON secret for credential-resolver

### DIFF
--- a/charts/incidentfox/templates/external-secrets.yaml
+++ b/charts/incidentfox/templates/external-secrets.yaml
@@ -379,6 +379,7 @@ spec:
     - secretKey: {{ $c.sharedAnthropicKey.secretKey | quote }}
       remoteRef:
         key: {{ $c.sharedAnthropicKey.remoteRefKey | quote }}
+        property: api_key
 {{- end }}
 
 {{- if $c.slackBot.enabled }}


### PR DESCRIPTION
## Summary
- The shared Anthropic API key in AWS Secrets Manager is stored as JSON (`{"api_key":"sk-ant-...","purpose":"..."}`)
- The ExternalSecret was syncing the entire JSON blob into the K8s secret
- The credential-resolver then injected `{"api_key":"sk-ant-...","purpose":"..."}` as the `x-api-key` header, which Anthropic rejected as `invalid x-api-key`
- Fix: add `property: api_key` to the ExternalSecret `remoteRef` to extract just the key string

## Context
This worked with the old sre-agent deploy script because it used `kubectl create secret --from-literal` with a plain string from GitHub Actions secrets. The Helm/ESO migration syncs from AWS Secrets Manager which stores the value as JSON.

## Test plan
- [ ] Deploy to staging
- [ ] Verify K8s secret `incidentfox-shared-anthropic` contains a plain `sk-ant-...` string (not JSON)
- [ ] Verify sandbox investigation completes successfully via Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)