### PR TITLE
fix(runner): Use shared StreamEvent from events module

### DIFF
--- a/unified-agent/src/unified_agent/core/runner.py
+++ b/unified-agent/src/unified_agent/core/runner.py
@@ -15,6 +15,7 @@ from typing import Any, AsyncIterator, Callable, Optional
 import litellm
 
 from .agent import Agent
+from .events import StreamEvent
 
 logger = logging.getLogger(__name__)
 
@@ -38,15 +39,6 @@ class RunResult:
     messages: list[dict] = field(default_factory=list)
     tool_calls: list[dict] = field(default_factory=list)
     status: str = "complete"  # complete, incomplete, error
-
-
-@dataclass
-class StreamEvent:
-    """Event emitted during agent execution."""
-
-    type: str  # thought, tool_start, tool_end, result, error
-    data: dict = field(default_factory=dict)
-    thread_id: str = ""
 
 
 class MaxTurnsExceeded(Exception):


### PR DESCRIPTION
## Summary
- `runner.py` defined its own `StreamEvent` dataclass without `to_sse()`, separate from `events.py`
- This caused sandbox pod SSE responses to serialize as `type: "unknown"` with Python repr strings instead of proper JSON events
- The orchestrator/slack-bot ignores `unknown` events, so investigation results never reached Slack
- Fix: remove duplicate class, import `StreamEvent` from `events.py` (which has `to_dict()` and `to_sse()`)

## Root cause
The `/execute` handler checks `hasattr(event, "to_sse")` to format events. Runner's `StreamEvent` lacked this method, so events fell through to the else branch producing `{"type": "unknown", "data": "StreamEvent(type='thought', ...)"}`.

## Test plan
- [ ] Deploy to staging
- [ ] Trigger investigation via Slack
- [ ] Verify response appears in Slack (not just "Starting investigation...")

🤖 Generated with [Claude Code](https://claude.com/claude-code)