### PR TITLE
fix(unified-agent): Enable Langfuse tracing via LiteLLM callback

### DIFF
--- a/unified-agent/src/unified_agent/sandbox/manager.py
+++ b/unified-agent/src/unified_agent/sandbox/manager.py
@@ -433,6 +433,8 @@ static_resources:
             },
             # Kubeconfig for K8s tools
             {"name": "KUBECONFIG", "value": "/home/agent/.kube/config"},
+            # LiteLLM observability callback (Langfuse)
+            {"name": "LITELLM_CALLBACKS", "value": "langfuse"},
         ]
 
         # Config-driven agents: TEAM_TOKEN enables loading config from Config Service


### PR DESCRIPTION
## Summary
- Langfuse credentials were passed to sandbox pods but LiteLLM was never configured to use them
- Add `LITELLM_CALLBACKS=langfuse` env var to sandbox container env so LiteLLM sends traces to Langfuse

## Test plan
- [ ] Deploy to staging, trigger investigation via Slack
- [ ] Check Langfuse dashboard for new traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)