### PR TITLE
fix(unified-agent): Add langfuse dependency for LiteLLM tracing

### DIFF
--- a/unified-agent/pyproject.toml
+++ b/unified-agent/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "aiohttp>=3.13.0",
 
     # Observability & Tracing
+    "langfuse>=2.0.0",  # Langfuse tracing (LiteLLM callback)
     "lmnr>=0.7.32",  # Laminar tracing
     "structlog>=24.4.0",
     "prometheus-client>=0.21.0",


### PR DESCRIPTION
## Summary
- `langfuse` Python package was missing from `pyproject.toml`
- LiteLLM requires it as an optional dependency to send traces
- The env vars (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`) and `LITELLM_CALLBACKS=langfuse` were all correctly configured but LiteLLM silently skipped the callback at runtime

## Test plan
- [ ] Deploy to staging (triggers Docker image rebuild with langfuse installed)
- [ ] Delete existing sandbox, trigger investigation via Slack
- [ ] Check Langfuse dashboard for new traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)