### PR TITLE
fix(sandbox): Forward CONFIG_SERVICE_URL to sandbox pods

### DIFF
--- a/unified-agent/src/unified_agent/sandbox/manager.py
+++ b/unified-agent/src/unified_agent/sandbox/manager.py
@@ -435,7 +435,10 @@ static_resources:
             {"name": "KUBECONFIG", "value": "/home/agent/.kube/config"},
         ]
 
-        # Config-driven agents: TEAM_TOKEN enables loading config from Config Service
+        # Config-driven agents: forward Config Service URL and TEAM_TOKEN
+        config_service_url = os.getenv("CONFIG_SERVICE_URL", "")
+        if config_service_url:
+            env.append({"name": "CONFIG_SERVICE_URL", "value": config_service_url})
         if team_token:
             env.append({"name": "TEAM_TOKEN", "value": team_token})
 


### PR DESCRIPTION
## Description

Sandbox pods were unable to reach Config Service because `CONFIG_SERVICE_URL` env var was not forwarded from the manager pod to sandbox containers. This caused config-driven agents (like the feature triage planner) to silently fail loading team configuration via `TEAM_TOKEN`, falling back to hardcoded default prompts.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Forward `CONFIG_SERVICE_URL` from manager pod environment to each sandbox pod in `_build_container_env()`
- Allows sandbox pods to correctly resolve and reach Config Service for team config loading
- Enables config-driven system prompts and agent configurations to work properly

## Testing

- [x] Manual testing performed (tested in Kubernetes environment)
- Verified sandbox pod now has `CONFIG_SERVICE_URL` env var set
- Verified config loads correctly from Config Service with TEAM_TOKEN
- Bot in channel C0ADSDTFF41 now receives correct feature triage agent prompt

## Deployment Notes

- [x] Backward compatible (no breaking changes)
- Fix enables proper use of existing config-driven agent feature