### PR TITLE
fix(unified-agent): Initialize Langfuse callback in LiteLLM runner

### DIFF
--- a/unified-agent/src/unified_agent/core/runner.py
+++ b/unified-agent/src/unified_agent/core/runner.py
@@ -19,6 +19,11 @@ from .events import StreamEvent
 
 logger = logging.getLogger(__name__)
 
+# Enable Langfuse tracing if credentials are configured
+if os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY"):
+    litellm.success_callback = ["langfuse"]
+    litellm.failure_callback = ["langfuse"]
+
 # Model alias mapping (short names to full LiteLLM model strings)
 MODEL_ALIASES = {
     "sonnet": "anthropic/claude-sonnet-4-20250514",


### PR DESCRIPTION
## Summary
- `LITELLM_CALLBACKS` env var does not auto-configure LiteLLM callbacks
- LiteLLM requires `litellm.success_callback = ["langfuse"]` set programmatically
- Added initialization at runner module load, gated on `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` being set

## Test plan
- [ ] Deploy to staging, delete existing sandboxes
- [ ] Trigger investigation via Slack
- [ ] Verify traces appear in Langfuse dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)