### PR TITLE
fix(unified-agent): Add langfuse dependency for litellm tracing

### DIFF
--- a/unified-agent/pyproject.toml
+++ b/unified-agent/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "aiohttp>=3.13.0",
 
     # Observability & Tracing
+    "langfuse>=2.51.0",  # Langfuse tracing (required by litellm callback)
     "lmnr>=0.7.32",  # Laminar tracing
     "structlog>=24.4.0",
     "prometheus-client>=0.21.0",


### PR DESCRIPTION
## Description

Sandbox pods crash with `Langfuse.__init__() got an unexpected keyword argument 'sdk_integration'` because langfuse is not listed as a dependency despite `LITELLM_CALLBACKS=langfuse` being set on sandbox pods.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `langfuse>=2.51.0` to unified-agent dependencies in `pyproject.toml`
- Version `>=2.51.0` required for the `sdk_integration` parameter that litellm passes

## Testing

- [x] Manual testing performed

## Deployment Notes

- [x] Requires container image rebuild
- [x] Backward compatible