### PR TITLE
fix(unified-agent): Pin langfuse<3 for LiteLLM compatibility

### DIFF
--- a/unified-agent/pyproject.toml
+++ b/unified-agent/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "aiohttp>=3.13.0",
 
     # Observability & Tracing
-    "langfuse>=2.0.0",  # Langfuse tracing (LiteLLM callback)
+    "langfuse>=2.6.0,<3.0.0",  # Langfuse tracing (LiteLLM callback, v3 breaks sdk_integration)
     "lmnr>=0.7.32",  # Laminar tracing
     "structlog>=24.4.0",
     "prometheus-client>=0.21.0",


### PR DESCRIPTION
## Summary
- LiteLLM 1.81.8 passes `sdk_integration="litellm"` to `Langfuse.__init__()` when langfuse >= 2.6.0
- langfuse v3 removed that parameter, causing `TypeError: __init__() got an unexpected keyword argument 'sdk_integration'`
- Pin to `langfuse>=2.6.0,<3.0.0` (latest v2 is 2.60.10) which supports `sdk_integration`

## Test plan
- [ ] Deploy, delete sandboxes, trigger Slack investigation
- [ ] Verify traces appear in Langfuse dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)