### PR TITLE
fix(helm): Fix ingress annotations and ENCRYPTION_KEY secret

### DIFF
--- a/charts/incidentfox/values.prod.yaml
+++ b/charts/incidentfox/values.prod.yaml
@@ -25,9 +25,7 @@ ingress:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/healthcheck-path: "/api/health"
-    alb.ingress.kubernetes.io/ssl-redirect: "443"
   host: "ui.incidentfox.ai"
   tls:
     enabled: true
@@ -120,6 +118,12 @@ externalSecrets:
       clientIdRemoteRefKey: incidentfox/prod/slack_client_id
       clientSecretRemoteRefKey: incidentfox/prod/slack_client_secret
       signingSecretRemoteRefKey: incidentfox/prod/slack_signing_secret
+    # Encryption key for config-service column encryption
+    encryptionKey:
+      enabled: true
+      secretName: incidentfox-encryption-key
+      secretKey: ENCRYPTION_KEY
+      remoteRefKey: incidentfox/prod/encryption_key
 
 services:
   configService:
@@ -149,7 +153,7 @@ services:
     oidc:
       enabled: false
     encryptionKey:
-      secretName: incidentfox-config-service
+      secretName: incidentfox-encryption-key
       secretKey: ENCRYPTION_KEY
     githubApp:
       enabled: true

--- a/charts/incidentfox/values.staging.yaml
+++ b/charts/incidentfox/values.staging.yaml
@@ -26,9 +26,7 @@ ingress:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/healthcheck-path: "/api/health"
-    alb.ingress.kubernetes.io/ssl-redirect: "443"
   host: "staging.incidentfox.ai"
   tls:
     enabled: true
@@ -155,6 +153,9 @@ services:
       failureThreshold: 5
     oidc:
       enabled: false
+    encryptionKey:
+      secretName: incidentfox-encryption-key
+      secretKey: ENCRYPTION_KEY
 
   orchestrator:
     enabled: true


### PR DESCRIPTION
## Summary
- Remove duplicate `listen-ports` and `ssl-redirect` from ingress annotations in prod and staging values (template already handles these conditionally when TLS is enabled)
- Fix prod ENCRYPTION_KEY to reference dedicated `incidentfox-encryption-key` secret instead of `incidentfox-config-service` (which won't contain this key after ESO takes over)
- Add `externalSecrets.contract.encryptionKey` config for prod so ESO creates the dedicated secret from AWS SM
- Add `services.configService.encryptionKey` to staging so the env var is actually injected (previously the ESO secret was created but never used)

## Context
Pre-Phase 4 cleanup: ensuring the Helm chart renders correctly before we do the full Helm adoption on prod. Also created `incidentfox/prod/encryption_key` in AWS Secrets Manager (extracted from existing K8s secret).

## Test plan
- [x] `helm template` renders cleanly for both prod and staging values
- [x] No duplicate annotations in rendered ingress
- [x] ENCRYPTION_KEY references correct secret name (`incidentfox-encryption-key`)
- [x] ExternalSecret for encryption key renders for prod
- [x] AWS SM secret `incidentfox/prod/encryption_key` created and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)