### PR TITLE
fix(deploy): Harden deploy workflow and fix gVisor installer for EKS

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -252,6 +252,7 @@ jobs:
           echo "Deploying with: incidentfox/${{ env.VALUES_FILE }}"
           helm upgrade --install incidentfox ./incidentfox \
             -n ${{ env.HELM_NAMESPACE }} \
+            --create-namespace \
             -f incidentfox/${{ env.VALUES_FILE }} \
             --no-hooks \
             --force \
@@ -302,16 +303,24 @@ jobs:
       - name: Wait for core services
         run: |
           echo "Waiting for core services to be ready..."
-          # Core services should start quickly (1-2 min)
-          kubectl rollout status deployment/incidentfox-config-service -n ${{ env.HELM_NAMESPACE }} --timeout=5m
-          kubectl rollout status deployment/incidentfox-orchestrator -n ${{ env.HELM_NAMESPACE }} --timeout=5m
-          kubectl rollout status deployment/incidentfox-agent -n ${{ env.HELM_NAMESPACE }} --timeout=5m
-          kubectl rollout status deployment/incidentfox-web-ui -n ${{ env.HELM_NAMESPACE }} --timeout=5m
+          NS="${{ env.HELM_NAMESPACE }}"
 
-          # K8s Gateway (optional - only if enabled)
-          if kubectl get deployment/incidentfox-k8s-gateway -n ${{ env.HELM_NAMESPACE }} &>/dev/null; then
-            kubectl rollout status deployment/incidentfox-k8s-gateway -n ${{ env.HELM_NAMESPACE }} --timeout=5m
-          fi
+          wait_for_deployment() {
+            local deploy=$1
+            if kubectl get deployment "$deploy" -n "$NS" &>/dev/null; then
+              echo "Waiting for $deploy..."
+              kubectl rollout status deployment/"$deploy" -n "$NS" --timeout=5m
+            else
+              echo "Skipping $deploy (not found)"
+            fi
+          }
+
+          # Core services should start quickly (1-2 min)
+          wait_for_deployment "incidentfox-config-service"
+          wait_for_deployment "incidentfox-orchestrator"
+          wait_for_deployment "incidentfox-agent"
+          wait_for_deployment "incidentfox-web-ui"
+          wait_for_deployment "incidentfox-k8s-gateway"
 
       - name: Wait for RAG services (slow startup)
         run: |

--- a/charts/incidentfox/templates/gvisor-installer.yaml
+++ b/charts/incidentfox/templates/gvisor-installer.yaml
@@ -75,31 +75,26 @@ spec:
           cp containerd-shim-runsc-v1 /host/usr/local/bin/containerd-shim-runsc-v1
           echo "runsc and shim installed"
 
-          # Configure containerd
+          # Configure containerd for gVisor runtime
+          # containerd uses /etc/containerd/config.toml (default path, no --config flag)
           echo "Configuring containerd..."
-          mkdir -p /host/etc/containerd
+          CONFIG=/host/etc/containerd/config.toml
 
-          # Remove any old/wrong gVisor runtime config (both old and new CRI paths)
-          sed -i '/\[plugins\..*containerd\.runtimes\.runsc\]/,/^\[/{ /^\[plugins/!d; /runtimes\.runsc/d; }' /host/etc/containerd/config.toml 2>/dev/null || true
-          # Also remove the old grpc.v1.cri format completely
-          sed -i '/\[plugins\."io\.containerd\.grpc\.v1\.cri"\.containerd\.runtimes\.runsc\]/,/^\[/d' /host/etc/containerd/config.toml 2>/dev/null || true
+          # Clean up any bad drop-in configs from previous installer versions
+          rm -f /host/etc/containerd/config.d/gvisor.toml 2>/dev/null || true
 
-          # Add gVisor runtime config (EKS containerd v3 format - uses cri.v1.runtime path)
-          if ! grep -q "io.containerd.cri.v1.runtime.*runtimes.runsc" /host/etc/containerd/config.toml 2>/dev/null; then
-            echo "Adding gVisor runtime configuration (containerd v3 format)..."
-            echo '' >> /host/etc/containerd/config.toml
-            echo "[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runsc]" >> /host/etc/containerd/config.toml
-            echo 'runtime_type = "io.containerd.runsc.v1"' >> /host/etc/containerd/config.toml
-            echo '' >> /host/etc/containerd/config.toml
-            echo "[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runsc.options]" >> /host/etc/containerd/config.toml
-            echo 'TypeUrl = "io.containerd.runsc.v1.options"' >> /host/etc/containerd/config.toml
+          # Add runsc runtime to containerd config (idempotent)
+          if ! grep -q 'runtimes.runsc' "$CONFIG" 2>/dev/null; then
+            echo "Adding runsc runtime to containerd config..."
+            printf '\n[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]\nruntime_type = "io.containerd.runsc.v1"\n' >> "$CONFIG"
           else
-            echo "containerd already configured for gVisor (v3 format)"
+            echo "runsc runtime already configured"
           fi
 
-          # Restart containerd using nsenter
+          # Restart containerd to pick up new runtime config
           echo "Restarting containerd..."
-          nsenter --target 1 --mount --uts --ipc --net --pid -- systemctl restart containerd || true
+          nsenter --target 1 --mount --uts --ipc --net --pid -- systemctl restart containerd
+          sleep 5
 
           echo "gVisor installation complete!"
 


### PR DESCRIPTION
## Summary
- Add `--create-namespace` to Helm deploy command to prevent failures when namespace doesn't exist
- Make "Wait for core services" step resilient — checks if deployment exists before waiting (matches pattern already used by restart step)
- Fix gVisor installer to write runtime config to `/etc/containerd/config.toml` (the actual active config) instead of the EKS template file or config.d drop-in (which crashed containerd)
- Clean up stale `config.d/gvisor.toml` from previous installer versions

## Context
A deploy from `longyi-07/telemetry-proposal-demo` (which had an old workflow version hardcoding `values.prod.yaml`) deployed prod config to the demo cluster, nuking the `incidentfox` staging namespace. Recovery revealed the gVisor installer was writing to the wrong containerd config path, causing nodes to crash when containerd was restarted.

## Test plan
- [x] Verified staging cluster fully recovered with all services running
- [x] Verified gVisor runtime works (sandbox pods running with `4.4.0` kernel / `Starting gVisor...` in dmesg)
- [x] Verified containerd restart doesn't crash nodes with the corrected config path
- [x] Verified investigation sandbox pods start successfully (2/2 Running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)