### PR TITLE
fix(helm): Make namespace creation conditional to prevent deletion on uninstall

### DIFF
--- a/charts/incidentfox/templates/namespace.yaml
+++ b/charts/incidentfox/templates/namespace.yaml
@@ -1,5 +1,7 @@
+{{- if ne (toString .Values.createNamespace) "false" }}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespace | quote }}
+{{- end }}
 

--- a/charts/incidentfox/values.prod.yaml
+++ b/charts/incidentfox/values.prod.yaml
@@ -2,6 +2,7 @@
 # Production environment for customer-facing workloads
 
 namespace: incidentfox-prod
+createNamespace: false
 
 # gVisor sandbox isolation for secure code execution
 gvisor:


### PR DESCRIPTION
## Summary
- Add `createNamespace` toggle to namespace template (defaults to creating namespace for backward compat)
- Set `createNamespace: false` in prod values to prevent `helm uninstall` from deleting the namespace and all resources in it

## Context
During Phase 4 prod migration, `helm uninstall` of a failed release deleted the entire `incidentfox-prod` namespace because it was labeled as Helm-managed. This wiped all secrets, services, and ingresses. The fix makes namespace creation opt-out for environments where the namespace is pre-created and should persist independently of the Helm release.

## Test plan
- [x] Verified `helm template` with `createNamespace: false` excludes the Namespace resource
- [x] Verified `helm template` without the flag still creates the Namespace (backward compat)
- [x] Prod is running successfully with Helm revision 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)