### PR TITLE
fix(helm): Auto-detect containerd CRI plugin path for gVisor installer

### DIFF
--- a/charts/incidentfox/templates/gvisor-installer.yaml
+++ b/charts/incidentfox/templates/gvisor-installer.yaml
@@ -83,10 +83,18 @@ spec:
           # Clean up any bad drop-in configs from previous installer versions
           rm -f /host/etc/containerd/config.d/gvisor.toml 2>/dev/null || true
 
+          # Detect containerd CRI plugin path (v2 uses cri.v1.runtime, v1 uses grpc.v1.cri)
+          if grep -q 'io.containerd.cri.v1.runtime' "$CONFIG" 2>/dev/null; then
+            CRI_PLUGIN='io.containerd.cri.v1.runtime'
+          else
+            CRI_PLUGIN='io.containerd.grpc.v1.cri'
+          fi
+          echo "Detected CRI plugin: $CRI_PLUGIN"
+
           # Add runsc runtime to containerd config (idempotent)
           if ! grep -q 'runtimes.runsc' "$CONFIG" 2>/dev/null; then
             echo "Adding runsc runtime to containerd config..."
-            printf '\n[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]\nruntime_type = "io.containerd.runsc.v1"\n' >> "$CONFIG"
+            printf '\n[plugins."%s".containerd.runtimes.runsc]\nruntime_type = "io.containerd.runsc.v1"\n' "$CRI_PLUGIN" >> "$CONFIG"
           else
             echo "runsc runtime already configured"
           fi


### PR DESCRIPTION
## Summary
- Auto-detect containerd CRI plugin path instead of hardcoding the v1 path
- Containerd v1.x uses `io.containerd.grpc.v1.cri` (demo cluster)
- Containerd v2.x uses `io.containerd.cri.v1.runtime` (prod cluster)
- Reads existing `config.toml` to pick the correct path

## Context
After Phase 4 Helm migration, sandbox pods on prod failed with `no runtime for "runsc" is configured`. Root cause: PR #322 hardcoded the containerd v1 CRI plugin path, but prod nodes run containerd v2.1.5 which uses a different path. Demo (containerd v1.7.29) was unaffected.

## Test plan
- [x] Prod r6i.xlarge node fixed via SSM — sandbox pods now start with gVisor
- [x] Verified demo cluster uses `grpc.v1.cri` path (containerd v1.7)
- [x] Verified prod cluster uses `cri.v1.runtime` path (containerd v2.1)
- [x] Helm upgrade applied to prod (revision 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)