### PR TITLE
fix: Separate ECR repos for sre-agent to fix deployment deadline error

### DIFF
--- a/sre-agent/k8s/server-deployment.yaml
+++ b/sre-agent/k8s/server-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       - name: server
         # Image tag is updated by deploy script using kubectl set image
         # Default :latest is only used if deployment is applied manually
-        image: 103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-agent:latest
+        image: 103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-sre-agent:latest
         imagePullPolicy: Always
         command: ["python", "/app/server.py"]
         ports:
@@ -33,7 +33,7 @@ spec:
         env:
         - name: SANDBOX_IMAGE
           # Updated by deploy script to match server image tag
-          value: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-agent:latest"
+          value: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-sre-agent:latest"
         - name: SANDBOX_NAMESPACE
           valueFrom:
             fieldRef:

--- a/sre-agent/scripts/deploy-prod.sh
+++ b/sre-agent/scripts/deploy-prod.sh
@@ -45,8 +45,8 @@ echo "   Image tag: $IMAGE_TAG"
 docker buildx create --use --name multiplatform 2>/dev/null || docker buildx use multiplatform
 docker buildx build \
     --platform linux/amd64 \
-    -t 103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-agent:${IMAGE_TAG} \
-    -t 103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-agent:latest \
+    -t 103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-sre-agent:${IMAGE_TAG} \
+    -t 103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-sre-agent:latest \
     --push \
     .
 
@@ -145,11 +145,11 @@ kubectl apply -f k8s/server-deployment.yaml -n incidentfox-prod
 echo ""
 echo "1️⃣2️⃣  Updating server to new image..."
 kubectl set image deployment/incidentfox-server \
-    server=103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-agent:${IMAGE_TAG} \
+    server=103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-sre-agent:${IMAGE_TAG} \
     -n incidentfox-prod
 # Also update SANDBOX_IMAGE env var so sandboxes use the same version
 kubectl set env deployment/incidentfox-server \
-    SANDBOX_IMAGE=103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-agent:${IMAGE_TAG} \
+    SANDBOX_IMAGE=103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-sre-agent:${IMAGE_TAG} \
     -n incidentfox-prod
 kubectl rollout status deployment/incidentfox-server -n incidentfox-prod --timeout=3m
 

--- a/sre-agent/scripts/setup-prod.sh
+++ b/sre-agent/scripts/setup-prod.sh
@@ -76,8 +76,8 @@ echo ""
 echo "2️⃣  Creating ECR repositories..."
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-# Create incidentfox-agent repository
-REPO_NAME="incidentfox-agent"
+# Create incidentfox-sre-agent repository
+REPO_NAME="incidentfox-sre-agent"
 if aws ecr describe-repositories --repository-names $REPO_NAME --region $REGION >/dev/null 2>&1; then
     echo "✅ Repository already exists: $REPO_NAME"
 else
@@ -286,7 +286,7 @@ echo "╚═══════════════════════�
 echo ""
 echo "📊 What was created:"
 echo "  ✅ EKS cluster: $CLUSTER_NAME"
-echo "  ✅ ECR repositories: incidentfox-agent, credential-resolver, slack-bot"
+echo "  ✅ ECR repositories: incidentfox-sre-agent, credential-resolver, slack-bot"
 echo "  ✅ agent-sandbox controller"
 echo "  ✅ gVisor runtime"
 echo "  ✅ Namespace: $NAMESPACE"


### PR DESCRIPTION
## Summary

Fixes deployment failures where `incidentfox-agent` exceeded its progress deadline by separating ECR repositories for `sre-agent` and `ai-agent`.

## Problem

The `sre-agent/scripts/deploy-prod.sh` was publishing to the `incidentfox-agent` ECR repository, overwriting the main AI agent image with SRE agent code. This caused Kubernetes liveness probe failures because the health server on port 8081 wasn't available—the container was running `sandbox_server.py` on port 8888 instead.

## Solution

- Renamed SRE agent ECR repository to `incidentfox-sre-agent` to avoid collision with the main `incidentfox-agent` image
- Updated all references in deployment scripts and Kubernetes configs
- Prevents future accidental overwrites between the two independent services

## Changes Made

- `sre-agent/scripts/deploy-prod.sh`: Update ECR repo tags to `incidentfox-sre-agent`
- `sre-agent/scripts/setup-prod.sh`: Create `incidentfox-sre-agent` repository instead of `incidentfox-agent`
- `sre-agent/k8s/server-deployment.yaml`: Update image references to use `incidentfox-sre-agent`

## Deployment Notes

- Requires creating new `incidentfox-sre-agent` ECR repository in production
- Re-run "Deploy to EKS" workflow with `agent` selected to rebuild the correct agent image
- No breaking changes; backward compatible