### PR TITLE
fix(deploy): Remove destructive --force flag from Helm upgrade

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -238,7 +238,6 @@ jobs:
             --create-namespace \
             -f incidentfox/${{ env.VALUES_FILE }} \
             --no-hooks \
-            --force \
             --timeout 5m
 
       - name: Restart deployments to pull latest images


### PR DESCRIPTION
## Description

Removes the `--force` flag from the Helm upgrade command in the EKS deployment workflow. This flag was causing the Ingress ALB to be deleted and recreated on every deploy, breaking DNS records and causing outages.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Root Cause

The `--force` flag was added as an incorrect replacement for the invalid `--force-conflicts` kubectl flag. `helm upgrade --force` has a destructive behavior: it deletes and recreates ALL resources rather than patching them in place.

This caused:
1. The Ingress ALB to be destroyed
2. A new ALB to be created with a different DNS name
3. `staging.incidentfox.ai` to point to a dead ALB until DNS propagated

## Why It's Safe to Remove

- The workflow already handles latest image pulls via explicit `kubectl rollout restart` steps
- `--force` is unnecessary for the intended functionality
- Without it, helm upgrade patches resources in place, preserving the Ingress ALB

## Testing

- [x] Manual testing performed
- [x] Verified staging site works after DNS update
- [x] No destructive resource recreation

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] No new warnings introduced
- [x] Branch is up to date with \`main\`

## Deployment Notes

- [x] Backward compatible
- No special considerations needed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)