### PR TITLE
feat: Registry-based tool dispatch, system prompt wiring, PagerDuty create incident

### DIFF
--- a/unified-agent/src/unified_agent/providers/base.py
+++ b/unified-agent/src/unified_agent/providers/base.py
@@ -53,6 +53,9 @@ class ProviderConfig:
     # Skills directory path
     skills_dir: Optional[str] = None
 
+    # Custom system prompt (from team config)
+    system_prompt: Optional[str] = None
+
     def __post_init__(self):
         if self.setting_sources is None:
             self.setting_sources = ["user", "project"]


### PR DESCRIPTION
## Summary
- Add `system_prompt` field to `ProviderConfig` so team configs can pass custom prompts to the LLM
- Wire custom system prompt from team config through `server.py` → `ProviderConfig` → `OpenHandsProvider`
- Replace hardcoded tool schemas/dispatch in OpenHandsProvider with auto-discovery from the tool registry (127+ tools now available)
- Add `pagerduty_create_incident` tool to both unified-agent and old agent codebase

## Test plan
- [ ] Deploy agent service, verify custom system prompt is applied for teams with config
- [ ] Verify registry tools (e.g. pagerduty_create_incident) are available to the LLM
- [ ] Verify built-in tools (bash, read_file, etc.) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)