### PR TITLE
feat: Add multi-app (white-label) Slack bot support

### DIFF
--- a/charts/incidentfox/templates/orchestrator.yaml
+++ b/charts/incidentfox/templates/orchestrator.yaml
@@ -61,6 +61,8 @@ spec:
                   key: {{ .Values.externalSecrets.contract.orchestratorInternal.internalTokenKey | quote }}
             {{- end }}
             {{- if .Values.externalSecrets.contract.slack.enabled }}
+            # DEPRECATED: Signing secret loaded from slack_apps DB table.
+            # Kept as fallback when no apps are configured in config service.
             - name: SLACK_BOT_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/incidentfox/templates/slack-bot.yaml
+++ b/charts/incidentfox/templates/slack-bot.yaml
@@ -72,7 +72,8 @@ spec:
             - name: FREE_TRIAL_DAYS
               value: {{ .Values.services.slackBot.freeTrial.days | default 7 | quote }}
             {{- if .Values.externalSecrets.contract.slackBot.enabled }}
-            # Slack OAuth credentials (for public distribution)
+            # Slack OAuth credentials (DEPRECATED: migrate to slack_apps DB table)
+            # Kept as fallback when no apps are configured in config service
             - name: SLACK_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/config_service/alembic/versions/20260208_multi_slack_app.py
+++ b/config_service/alembic/versions/20260208_multi_slack_app.py
@@ -1,0 +1,99 @@
+"""Add slack_apps table and slack_app_slug to slack_installations.
+
+Enables multi-app support: each row in slack_apps represents a separate
+Slack app registration (with its own signing_secret, client_id, client_secret).
+The slack_installations table gains a foreign key to track which app each
+workspace installed.
+
+Revision ID: 20260208_multi_slack_app
+Revises: 20260208_org_admin_token_cols
+Create Date: 2026-02-08
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import Text
+
+revision = "20260208_multi_slack_app"
+down_revision = "20260208_org_admin_token_cols"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # 1. Create slack_apps table
+    op.create_table(
+        "slack_apps",
+        sa.Column("slug", sa.String(64), primary_key=True),
+        sa.Column("display_name", sa.String(255), nullable=False),
+        sa.Column("app_id", sa.String(255), nullable=True),
+        # Encrypted via EncryptedText in models.py
+        sa.Column(
+            "client_id",
+            Text,
+            nullable=True,
+            comment="Slack OAuth client ID (encrypted with Fernet)",
+        ),
+        sa.Column(
+            "client_secret",
+            Text,
+            nullable=True,
+            comment="Slack OAuth client secret (encrypted with Fernet)",
+        ),
+        sa.Column(
+            "signing_secret",
+            Text,
+            nullable=True,
+            comment="Slack webhook signing secret (encrypted with Fernet)",
+        ),
+        sa.Column("bot_scopes", Text, nullable=True),
+        sa.Column("oauth_redirect_url", sa.String(512), nullable=True),
+        sa.Column("is_active", sa.Boolean, server_default="true", nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+    )
+
+    op.create_index("ix_slack_apps_app_id", "slack_apps", ["app_id"], unique=True)
+
+    # 2. Add slack_app_slug column to slack_installations (nullable initially)
+    op.add_column(
+        "slack_installations",
+        sa.Column(
+            "slack_app_slug",
+            sa.String(64),
+            sa.ForeignKey("slack_apps.slug"),
+            nullable=True,
+        ),
+    )
+
+    # 3. Drop old unique index, create new one that includes slack_app_slug
+    op.drop_index("ix_slack_installations_lookup", table_name="slack_installations")
+    op.create_index(
+        "ix_slack_installations_lookup",
+        "slack_installations",
+        ["slack_app_slug", "enterprise_id", "team_id", "user_id"],
+        unique=True,
+    )
+
+
+def downgrade():
+    # Restore old unique index
+    op.drop_index("ix_slack_installations_lookup", table_name="slack_installations")
+    op.create_index(
+        "ix_slack_installations_lookup",
+        "slack_installations",
+        ["enterprise_id", "team_id", "user_id"],
+        unique=True,
+    )
+
+    # Remove slack_app_slug column
+    op.drop_column("slack_installations", "slack_app_slug")
+
+    # Drop slack_apps table
+    op.drop_index("ix_slack_apps_app_id", table_name="slack_apps")
+    op.drop_table("slack_apps")

--- a/orchestrator/src/incidentfox_orchestrator/api_server.py
+++ b/orchestrator/src/incidentfox_orchestrator/api_server.py
@@ -218,22 +218,19 @@ def create_app() -> FastAPI:
             app_.state.correlation_service = None
             _log("correlation_service_not_configured")
 
-        # Slack Bolt integration for Slack webhooks
-        slack_signing_secret = (os.getenv("SLACK_SIGNING_SECRET") or "").strip()
-        if slack_signing_secret:
-            from incidentfox_orchestrator.webhooks.slack_bolt_app import (
-                SlackBoltIntegration,
-            )
+        # Slack Bolt integration for Slack webhooks (multi-app support)
+        # Loads signing secrets from config service DB; falls back to
+        # SLACK_SIGNING_SECRET env var if no apps configured in DB.
+        from incidentfox_orchestrator.webhooks.slack_bolt_app import (
+            SlackBoltIntegration,
+        )
 
-            app_.state.slack_bolt = SlackBoltIntegration(
-                config_service=app_.state.config_service,
-                agent_api=app_.state.agent_api,
-                audit_api=app_.state.audit_api,
-            )
-            _log("slack_bolt_initialized")
-        else:
-            app_.state.slack_bolt = None
-            _log("slack_bolt_not_configured", reason="SLACK_SIGNING_SECRET not set")
+        app_.state.slack_bolt = SlackBoltIntegration(
+            config_service=app_.state.config_service,
+            agent_api=app_.state.agent_api,
+            audit_api=app_.state.audit_api,
+        )
+        _log("slack_bolt_initialized", apps=app_.state.slack_bolt.list_slugs())
 
         # Google Chat integration
         google_chat_project_id = (os.getenv("GOOGLE_CHAT_PROJECT_ID") or "").strip()

--- a/orchestrator/src/incidentfox_orchestrator/clients.py
+++ b/orchestrator/src/incidentfox_orchestrator/clients.py
@@ -454,6 +454,26 @@ class ConfigServiceClient:
         r.raise_for_status()
         return dict(r.json())
 
+    def list_slack_apps(self) -> List[Dict[str, Any]]:
+        """
+        List all active Slack app configurations from config service.
+
+        Returns list of dicts with: slug, display_name, app_id,
+        client_id, client_secret, signing_secret, bot_scopes, etc.
+        """
+        url = f"{self.base_url}/api/v1/internal/slack/apps"
+        headers = {"X-Internal-Service": "orchestrator"}
+        try:
+            if self._http is not None:
+                r = self._http.get(url, headers=headers)
+            else:
+                with httpx.Client(timeout=15.0) as c:
+                    r = c.get(url, headers=headers)
+            r.raise_for_status()
+            return list(r.json())
+        except Exception:
+            return []
+
 
 class PipelineApiClient:
     def __init__(

--- a/orchestrator/src/incidentfox_orchestrator/webhooks/slack_bolt_app.py
+++ b/orchestrator/src/incidentfox_orchestrator/webhooks/slack_bolt_app.py
@@ -1,20 +1,21 @@
 """
-Slack Bolt app for multi-tenant webhook handling.
+Slack Bolt app for multi-tenant, multi-app webhook handling.
 
 Integrates Slack Bolt SDK with the existing multi-tenant architecture:
-- Signature verification via Bolt (automatic)
+- Signature verification via Bolt (automatic, per-app signing secret)
 - Event handling with async background processing
 - Interaction handling for feedback buttons
 
-Note: This does NOT use Bolt's OAuth/installation store since we manage
-tokens via Config Service. The signing_secret is shared across all tenants,
-but bot tokens are resolved per-team via Config Service lookup.
+Supports multiple Slack apps (white-label): each app has its own
+AsyncApp instance with a unique signing_secret. Apps are loaded from
+the config service at startup.
 """
 
 from __future__ import annotations
 
+import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Optional
 
 from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
 from slack_bolt.async_app import AsyncApp
@@ -26,17 +27,16 @@ if TYPE_CHECKING:
         ConfigServiceClient,
     )
 
+logger = logging.getLogger(__name__)
 
-def create_bolt_app() -> AsyncApp:
+
+def create_bolt_app(signing_secret: str) -> AsyncApp:
     """
     Create Slack Bolt async app for webhook handling.
 
-    Uses SLACK_SIGNING_SECRET for signature verification.
     Does not use a bot token here - tokens are resolved per-team
     when processing events via Config Service.
     """
-    signing_secret = (os.getenv("SLACK_SIGNING_SECRET") or "").strip()
-
     app = AsyncApp(
         signing_secret=signing_secret,
         # Don't use a global token - we resolve per-team
@@ -55,10 +55,11 @@ def create_bolt_handler(app: AsyncApp) -> AsyncSlackRequestHandler:
 
 class SlackBoltIntegration:
     """
-    Manages Slack Bolt app lifecycle and service client references.
+    Manages multiple Slack Bolt app instances for multi-app support.
 
-    This class is initialized in the FastAPI lifespan and provides
-    access to service clients from within Bolt handlers.
+    Each registered Slack app (from config service) gets its own AsyncApp
+    with its own signing_secret. The handler is selected by slug from the
+    webhook URL path.
     """
 
     def __init__(
@@ -71,10 +72,65 @@ class SlackBoltIntegration:
         self.agent_api = agent_api
         self.audit_api = audit_api
 
-        self.app = create_bolt_app()
-        self.handler = create_bolt_handler(self.app)
+        self._apps: Dict[str, AsyncApp] = {}
+        self._handlers: Dict[str, AsyncSlackRequestHandler] = {}
 
-        # Register handlers after app is created
+        # Load apps from config service, fall back to env var
+        self._load_apps()
+
+        # Legacy: also keep a default app/handler for backward compat
+        if not self._apps:
+            signing_secret = (os.getenv("SLACK_SIGNING_SECRET") or "").strip()
+            if signing_secret:
+                self._create_app("default", signing_secret)
+
+        # Expose first app as legacy .app/.handler for backward compat
+        if self._apps:
+            first_slug = next(iter(self._apps))
+            self.app = self._apps[first_slug]
+            self.handler = self._handlers[first_slug]
+        else:
+            self.app = create_bolt_app("")
+            self.handler = create_bolt_handler(self.app)
+
+    def _load_apps(self):
+        """Load Slack app configs from config service."""
+        try:
+            apps = self.config_service.list_slack_apps()
+        except Exception as e:
+            logger.warning(f"Failed to load Slack apps from config service: {e}")
+            apps = []
+
+        for app_config in apps:
+            slug = app_config.get("slug")
+            signing_secret = app_config.get("signing_secret")
+            if slug and signing_secret:
+                self._create_app(slug, signing_secret)
+            else:
+                logger.warning(f"Skipping Slack app with missing slug or signing_secret: {app_config}")
+
+        if apps:
+            logger.info(f"Loaded {len(self._apps)} Slack app(s): {list(self._apps.keys())}")
+
+    def _create_app(self, slug: str, signing_secret: str):
+        """Create a Bolt AsyncApp for a given slug and register handlers."""
+        bolt_app = create_bolt_app(signing_secret)
+
         from incidentfox_orchestrator.webhooks.slack_handlers import register_handlers
 
-        register_handlers(self.app, self)
+        register_handlers(bolt_app, self)
+
+        self._apps[slug] = bolt_app
+        self._handlers[slug] = create_bolt_handler(bolt_app)
+
+    def get_handler(self, slug: str) -> Optional[AsyncSlackRequestHandler]:
+        """Get the request handler for a specific app slug."""
+        return self._handlers.get(slug)
+
+    def get_app(self, slug: str) -> Optional[AsyncApp]:
+        """Get the AsyncApp for a specific app slug."""
+        return self._apps.get(slug)
+
+    def list_slugs(self) -> list:
+        """List all loaded app slugs."""
+        return list(self._apps.keys())

--- a/slack-bot/app_registry.py
+++ b/slack-bot/app_registry.py
@@ -1,0 +1,225 @@
+"""
+Multi-app Slack Bot registry.
+
+Manages multiple Slack Bolt App instances, one per configured Slack app
+(white-label support). Each App has its own signing_secret, client_id,
+and client_secret. Handlers are shared across all apps.
+
+Usage:
+    registry = SlackAppRegistry(config_service_url="http://...")
+    registry.load_all()
+
+    handler = registry.get_handler("incidentfox")
+    handler.handle(flask_request)
+"""
+
+import logging
+import os
+from typing import Dict, Optional
+
+import requests
+from slack_bolt import App
+from slack_bolt.adapter.flask import SlackRequestHandler
+from slack_bolt.oauth.oauth_settings import OAuthSettings
+from slack_sdk.oauth.state_store import FileOAuthStateStore
+
+from installation_store import ConfigServiceInstallationStore
+
+logger = logging.getLogger(__name__)
+
+CONFIG_SERVICE_URL = os.environ.get(
+    "CONFIG_SERVICE_URL",
+    "http://config-service-svc.incidentfox-prod.svc.cluster.local:8080",
+)
+
+
+class SlackAppRegistry:
+    """
+    Registry of Slack Bolt App instances, one per configured Slack app.
+
+    Loads app configurations from the config service and creates a Bolt App
+    per slug. All apps share the same event/action/view handlers but have
+    independent signing secrets and OAuth credentials.
+    """
+
+    def __init__(self, config_service_url: str = None):
+        self._config_service_url = (config_service_url or CONFIG_SERVICE_URL).rstrip("/")
+        self._apps: Dict[str, App] = {}
+        self._handlers: Dict[str, SlackRequestHandler] = {}
+        self._credentials: Dict[str, dict] = {}
+
+    def load_all(self):
+        """Fetch all active Slack apps from config service and create Bolt instances."""
+        try:
+            response = requests.get(
+                f"{self._config_service_url}/api/v1/internal/slack/apps",
+                headers={"X-Internal-Service": "slack-bot"},
+                timeout=15,
+            )
+            response.raise_for_status()
+            apps = response.json()
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Failed to load Slack apps from config service: {e}")
+            apps = []
+
+        if not apps:
+            logger.warning("No Slack apps found in config service, falling back to env vars")
+            self._create_from_env()
+            return
+
+        for app_config in apps:
+            try:
+                self._create_bolt_app(app_config)
+            except Exception as e:
+                logger.error(
+                    f"Failed to create Bolt app for slug={app_config.get('slug')}: {e}"
+                )
+
+        logger.info(f"Loaded {len(self._apps)} Slack app(s): {list(self._apps.keys())}")
+
+    def _create_from_env(self):
+        """Fallback: create a single app from environment variables (backward compat)."""
+        signing_secret = os.environ.get("SLACK_SIGNING_SECRET")
+        client_id = os.environ.get("SLACK_CLIENT_ID")
+        client_secret = os.environ.get("SLACK_CLIENT_SECRET")
+        bot_token = os.environ.get("SLACK_BOT_TOKEN")
+        base_url = os.environ.get("SLACK_BASE_URL", "https://slack.incidentfox.ai")
+
+        slug = "default"
+
+        if client_id and client_secret:
+            oauth_settings = OAuthSettings(
+                client_id=client_id,
+                client_secret=client_secret,
+                scopes=_default_scopes(),
+                installation_store=ConfigServiceInstallationStore(
+                    client_id=client_id,
+                    slack_app_slug=slug,
+                ),
+                state_store=FileOAuthStateStore(
+                    expiration_seconds=600, base_dir="/tmp/slack-oauth-states"
+                ),
+                redirect_uri=f"{base_url}/slack/{slug}/oauth_redirect",
+            )
+            bolt_app = App(
+                signing_secret=signing_secret,
+                oauth_settings=oauth_settings,
+            )
+        else:
+            bolt_app = App(
+                token=bot_token,
+                signing_secret=signing_secret,
+            )
+
+        self._register_handlers(bolt_app)
+        self._apps[slug] = bolt_app
+        self._handlers[slug] = SlackRequestHandler(bolt_app)
+        self._credentials[slug] = {
+            "slug": slug,
+            "display_name": "IncidentFox",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "signing_secret": signing_secret,
+            "oauth_redirect_url": f"{base_url}/slack/{slug}/oauth_redirect",
+            "bot_scopes": ",".join(_default_scopes()),
+        }
+        logger.info(f"Created default app from env vars (slug={slug})")
+
+    def _create_bolt_app(self, app_config: dict):
+        """Create a Bolt App from a config service app record."""
+        slug = app_config["slug"]
+        signing_secret = app_config.get("signing_secret")
+        client_id = app_config.get("client_id")
+        client_secret = app_config.get("client_secret")
+        bot_scopes = (app_config.get("bot_scopes") or "").split(",")
+        bot_scopes = [s.strip() for s in bot_scopes if s.strip()] or _default_scopes()
+        redirect_uri = app_config.get("oauth_redirect_url") or ""
+
+        if client_id and client_secret:
+            oauth_settings = OAuthSettings(
+                client_id=client_id,
+                client_secret=client_secret,
+                scopes=bot_scopes,
+                installation_store=ConfigServiceInstallationStore(
+                    client_id=client_id,
+                    slack_app_slug=slug,
+                ),
+                state_store=FileOAuthStateStore(
+                    expiration_seconds=600,
+                    base_dir=f"/tmp/slack-oauth-states-{slug}",
+                ),
+                redirect_uri=redirect_uri,
+            )
+            bolt_app = App(
+                signing_secret=signing_secret,
+                oauth_settings=oauth_settings,
+            )
+        else:
+            bolt_app = App(
+                signing_secret=signing_secret,
+            )
+
+        self._register_handlers(bolt_app)
+        self._apps[slug] = bolt_app
+        self._handlers[slug] = SlackRequestHandler(bolt_app)
+        self._credentials[slug] = app_config
+        logger.info(f"Created Bolt app for slug={slug} (display_name={app_config.get('display_name')})")
+
+    def _register_handlers(self, bolt_app: App):
+        """Register all event/action/view handlers on a Bolt App instance."""
+        # Import from app module — handlers are defined there as module-level functions
+        from app import register_all_handlers
+
+        register_all_handlers(bolt_app)
+
+    def get_handler(self, slug: str) -> Optional[SlackRequestHandler]:
+        """Get the Flask request handler for a given app slug."""
+        return self._handlers.get(slug)
+
+    def get_app(self, slug: str) -> Optional[App]:
+        """Get the Bolt App for a given app slug."""
+        return self._apps.get(slug)
+
+    def get_credentials(self, slug: str) -> Optional[dict]:
+        """Get the app credentials for a given slug."""
+        return self._credentials.get(slug)
+
+    def list_slugs(self) -> list:
+        """List all loaded app slugs."""
+        return list(self._apps.keys())
+
+    @property
+    def default_slug(self) -> Optional[str]:
+        """Return the first available slug as default."""
+        slugs = self.list_slugs()
+        return slugs[0] if slugs else None
+
+
+def _default_scopes() -> list:
+    """Default Slack bot scopes."""
+    return [
+        "app_mentions:read",
+        "channels:history",
+        "channels:join",
+        "channels:read",
+        "chat:write",
+        "chat:write.customize",
+        "commands",
+        "files:read",
+        "files:write",
+        "groups:history",
+        "groups:read",
+        "im:history",
+        "im:read",
+        "im:write",
+        "links:read",
+        "links:write",
+        "links.embed:write",
+        "metadata.message:read",
+        "mpim:history",
+        "mpim:read",
+        "reactions:read",
+        "reactions:write",
+        "usergroups:read",
+        "users:read",
+    ]

--- a/slack-bot/config_client.py
+++ b/slack-bot/config_client.py
@@ -74,6 +74,7 @@ class ConfigServiceClient:
         slack_team_id: str,
         slack_team_name: str,
         installer_user_id: str = None,
+        slack_app_slug: str = None,
     ) -> Dict[str, Any]:
         """
         Provision a new workspace in config_service.
@@ -91,15 +92,19 @@ class ConfigServiceClient:
 
         try:
             # Step 1: Create org node
+            metadata = {
+                "slack_team_id": slack_team_id,
+                "slack_team_name": slack_team_name,
+                "installer_user_id": installer_user_id,
+                "provisioned_at": datetime.utcnow().isoformat(),
+            }
+            if slack_app_slug:
+                metadata["slack_app_slug"] = slack_app_slug
+
             org_response = self._create_org_node(
                 org_id=org_id,
                 name=slack_team_name,
-                metadata={
-                    "slack_team_id": slack_team_id,
-                    "slack_team_name": slack_team_name,
-                    "installer_user_id": installer_user_id,
-                    "provisioned_at": datetime.utcnow().isoformat(),
-                },
+                metadata=metadata,
             )
             logger.info(
                 f"Created org node for workspace {slack_team_name}: {org_response}"

--- a/slack-bot/installation_store.py
+++ b/slack-bot/installation_store.py
@@ -38,10 +38,12 @@ class ConfigServiceInstallationStore(InstallationStore):
         base_url: str = None,
         service_name: str = "slack-bot",
         client_id: str = None,
+        slack_app_slug: str = None,
     ):
         self.base_url = (base_url or CONFIG_SERVICE_URL).rstrip("/")
         self.service_name = service_name
         self.client_id = client_id
+        self.slack_app_slug = slack_app_slug
 
     def _headers(self):
         """Headers for internal service calls."""
@@ -70,6 +72,7 @@ class ConfigServiceInstallationStore(InstallationStore):
                 "team_id": installation.team_id,
                 "user_id": None,  # Bot-level installation
                 "app_id": installation.app_id,
+                "slack_app_slug": self.slack_app_slug,
                 "bot_token": installation.bot_token,
                 "bot_id": installation.bot_id,
                 "bot_user_id": installation.bot_user_id,
@@ -112,6 +115,7 @@ class ConfigServiceInstallationStore(InstallationStore):
                 "team_id": installation.team_id,
                 "user_id": installation.user_id,
                 "app_id": installation.app_id,
+                "slack_app_slug": self.slack_app_slug,
                 "bot_token": installation.bot_token,
                 "bot_id": installation.bot_id,
                 "bot_user_id": installation.bot_user_id,
@@ -177,6 +181,8 @@ class ConfigServiceInstallationStore(InstallationStore):
             "team_id": team_id,
             "is_enterprise_install": is_enterprise_install or False,
         }
+        if self.slack_app_slug:
+            params["slack_app_slug"] = self.slack_app_slug
         if enterprise_id:
             params["enterprise_id"] = enterprise_id
         if user_id:
@@ -280,6 +286,8 @@ class ConfigServiceInstallationStore(InstallationStore):
         )
 
         params = {"team_id": team_id}
+        if self.slack_app_slug:
+            params["slack_app_slug"] = self.slack_app_slug
         if enterprise_id:
             params["enterprise_id"] = enterprise_id
         if user_id:


### PR DESCRIPTION
## Description

Enable distributing multiple separate Slack bots (e.g., IncidentFox, CustomerSupportBot) as SaaS products. Each bot gets its own Slack app registration, signing secret, and OAuth credentials stored in the database. Services route incoming webhooks by app slug from the URL path.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Related Issues

Closes #

## Changes Made

**Database & Config Service:**
- Add `slack_apps` table to store per-app Slack credentials (encrypted with Fernet)
- Add `slack_app_slug` FK column to `slack_installations` to track which app each workspace installed
- Add `/api/v1/internal/slack/apps` CRUD endpoints for managing app registrations

**slack-bot Service (Flask):**
- Create `app_registry.py`: `SlackAppRegistry` class that loads apps from DB and manages Bolt App instances per slug
- Refactor Flask routes to use slug-based paths: `/slack/<slug>/events`, `/slack/<slug>/install`, `/slack/<slug>/oauth_redirect`
- Extract `register_all_handlers()` function to dynamically register handlers on any Bolt App
- Update `installation_store.py` and `config_client.py` to pass `slack_app_slug` parameter
- Maintain backward-compatible legacy routes (`/slack/events` → default app)

**orchestrator Service (FastAPI):**
- Rewrite `SlackBoltIntegration` to manage multiple AsyncApp instances (one per slug)
- Add `_load_apps()` method to fetch configs from config service at startup
- Update webhook routes to `/slack/{slug}/events` and `/slack/{slug}/interactions`
- Add `list_slack_apps()` method to `ConfigServiceClient`

**Helm Chart:**
- Mark Slack OAuth credentials as deprecated (still supported for backward compatibility)

## Testing

### Test Plan

- [x] Manual testing performed
- [x] Tested in Kubernetes environment

### Testing Steps

1. Run Alembic migration: `alembic upgrade head` (creates slack_apps table)
2. Insert app configs into slack_apps: `POST /api/v1/internal/slack/apps`
3. Verify app is loaded: Check orchestrator/slack-bot logs for "Loaded X app(s)"
4. Test OAuth install flow at `/slack/{slug}/install`
5. Send event to new webhook URL `/slack/{slug}/events` and verify signature verification works
6. Verify legacy routes `/slack/events` still work for backward compatibility

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Documentation updated (README, docs/, etc.)
- [x] Tests passing

## Deployment Notes

- [x] Requires database migration
- [x] Backward compatible

**Migration:** `20260208_multi_slack_app` creates slack_apps table and updates slack_installations schema. Run `alembic upgrade head` before deploying.

**Admin Workflow:** Create Slack app on api.slack.com → `POST /api/v1/internal/slack/apps` with credentials → Update Event URL to `https://slack.incidentfox.ai/slack/{slug}/events` → Restart services or auto-reload.