### PR TITLE
fix(web-ui): Load skills from dedicated API endpoint

### DIFF
--- a/web_ui/src/app/team/tools/page.tsx
+++ b/web_ui/src/app/team/tools/page.tsx
@@ -315,8 +315,16 @@ export default function TeamToolsPage() {
         console.error('Failed to load integration schemas:', e);
       }
 
-      // Load skills catalog from effective config
-      setSkillsCatalog(data.built_in_skills || []);
+      // Load skills catalog from dedicated endpoint
+      try {
+        const skillsRes = await fetch('/api/team/skills');
+        if (skillsRes.ok) {
+          const skillsData = await skillsRes.json();
+          setSkillsCatalog(skillsData.skills || []);
+        }
+      } catch (e) {
+        console.error('Failed to load skills catalog:', e);
+      }
     } catch (e) {
       console.error('Failed to load tools/MCPs:', e);
     } finally {


### PR DESCRIPTION
## Summary
- The tools page was reading `built_in_skills` from the `/api/v1/config/me` response, but that endpoint uses `config_repository.compute_effective_config()` which only merges DB configs — it never adds `built_in_skills`
- Changed to fetch skills from the dedicated `/api/team/skills` endpoint (which proxies to `/api/v1/team/skills/catalog`), matching how the agents page already loads skills
- This fixes the "0 Skills" display on the tools page

## Test plan
- [ ] Deploy web-ui
- [ ] Verify tools page shows 17 skills in the violet Skills section
- [ ] Verify skills are grouped by category (methodology, observability, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)