### PR TITLE
feat(slack-bot): Include thread context for all investigation triggers

### DIFF
--- a/slack-bot/app.py
+++ b/slack-bot/app.py
@@ -1710,7 +1710,12 @@ def handle_mention(event, say, client, context):
     logger.info(f"Images attached: {len(images)}")
     logger.info(f"File attachments: {len(file_attachments)}")
 
-    if not prompt_text and not images and not file_attachments and not thread_context_text:
+    if (
+        not prompt_text
+        and not images
+        and not file_attachments
+        and not thread_context_text
+    ):
         say(
             text="Hey! What would you like me to investigate?",
             thread_ts=thread_ts,
@@ -3070,7 +3075,9 @@ def handle_nudge_invoke(ack, body, client, context, respond):
             bot_user_id=bot_user_id,
         )
         if thread_context_text:
-            logger.info(f"Thread context enrichment added for nudge in thread {thread_ts}")
+            logger.info(
+                f"Thread context enrichment added for nudge in thread {thread_ts}"
+            )
     except Exception as e:
         logger.warning(f"Failed to fetch thread context for nudge: {e}")
 


### PR DESCRIPTION
## Description

Enable IncidentFox to read thread history and include relevant context whenever it's triggered—whether via direct @mention or nudge. This ensures the bot has full conversation context to provide better insights.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **handle_mention**: Don't discard thread context when prompt is empty. If only @mentioning the bot without text in a thread, the bot now uses thread history as context and sends a default prompt to the agent.
- **handle_nudge_invoke**: Fetch and prepend thread context using the same `_format_thread_context` helper as direct mentions. Thread context shows all human messages since bot's last response (or all messages if bot is new to the thread).

## Testing

- Manual testing with bot mentions in active threads
- Manual testing with nudge triggers in multi-message threads

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] No new warnings introduced
- [x] Reuses existing `_format_thread_context` helper
- [x] Backward compatible

## Additional Context

This builds on commit 60847b0 which added thread context enrichment to `handle_mention`. These changes extend that pattern to ensure all investigation triggers (including nudge-initiated ones) have full thread context.

## Deployment Notes

- [x] Backward compatible