### PR TITLE
fix: Resolve production sandbox timeouts and warnings

### DIFF
--- a/charts/incidentfox/values.template.yaml
+++ b/charts/incidentfox/values.template.yaml
@@ -24,12 +24,11 @@ global:
   imagePullPolicy: IfNotPresent
 
   # ===================================================================
-  # REQUIRED: Docker Registry Authentication
+  # OPTIONAL: Docker Registry Authentication
   # ===================================================================
-  # Kubernetes secret for pulling private images from Docker Hub
-  # This secret should contain your license key for authentication
-  imagePullSecrets:
-    - name: incidentfox-registry
+  # Image pull secrets (empty by default - ECR auth handled via IAM roles)
+  # Add entries if using a private registry that requires credentials
+  imagePullSecrets: []
 
   # ===================================================================
   # REQUIRED: Database Configuration

--- a/charts/incidentfox/values.yaml
+++ b/charts/incidentfox/values.yaml
@@ -3,9 +3,8 @@ namespace: incidentfox
 global:
   imagePullPolicy: IfNotPresent
 
-  # Docker registry authentication for private images
-  imagePullSecrets:
-    - name: incidentfox-registry
+  # Image pull secrets (empty - ECR auth handled via IAM roles)
+  imagePullSecrets: []
 
   # External DB (recommended). Provide via External Secrets -> K8s Secret -> env.
   database:


### PR DESCRIPTION
## Summary

Fixed three production issues affecting incidentfox-prod cluster:

1. **Sandbox timeout errors** - Installed missing `agent-sandbox-controller` StatefulSet that was never deployed to prod. CRDs existed but the controller reconciling them was absent, causing all investigation requests to fail after 120s timeout. ✓ FIXED

2. **ExternalSecrets sync failures on demo** - Created missing `ClusterSecretStore aws-secrets-manager` on demo cluster. All 14 ExternalSecrets now syncing successfully. ✓ FIXED

3. **Image pull secret warnings** - Removed unused `incidentfox-registry` imagePullSecrets configuration. ECR authentication is handled via IAM roles on EKS, not image pull secrets. Eliminates harmless but noisy warnings on all pod deployments. ✓ FIXED

## Changes Made

- Updated Helm values to remove hardcoded `imagePullSecrets` reference
- Updated values template documentation to clarify ECR auth is IAM-based
- Verified all fixes on prod/demo clusters

## Deployment Notes

- [x] Requires configuration changes (Helm values update, run helm upgrade)
- [x] Backward compatible

## Related Issues

These fixes resolve "Sandbox failed to start within timeout" errors reported from incidentfox-prod.

🤖 Generated with Claude Code