### PR TITLE
fix(slack-bot): Show redacted secrets and remove unused elasticsearch SDK

### DIFF
--- a/sre-agent/pyproject.toml
+++ b/sre-agent/pyproject.toml
@@ -25,9 +25,6 @@ dependencies = [
     "slack-sdk>=3.27.0",
     "atlassian-python-api>=3.41.0",  # Confluence integration
 
-    # Logging & Search
-    "elasticsearch>=8.0.0",
-
     # Utilities
     "pyyaml>=6.0",
 

--- a/unified-agent/pyproject.toml
+++ b/unified-agent/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
 
     # Monitoring & Observability Backends
     "datadog-api-client>=2.20.0",
-    "elasticsearch>=8.0.0",
 
     # VCS & Collaboration
     "PyGithub>=2.1.0",


### PR DESCRIPTION
## Summary
- Secret fields in the Slack integration config UI now show masked values (`****`) when already configured, instead of an empty field
- Save handler detects unchanged redacted values (all asterisks) and preserves the existing secret
- Removed unused `elasticsearch` SDK dependency from unified-agent and sre-agent (both use REST API, not the SDK)

## Test plan
- [ ] Open an integration config in Slack that has a saved password/API key
- [ ] Verify the field shows `****` instead of blank
- [ ] Save without changing the password — verify the existing value is preserved
- [ ] Save with a new password — verify the new value is stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)