### PR TITLE
fix: Handle Grafana Edit button modal failure with video block fallback

### DIFF
--- a/slack-bot/app.py
+++ b/slack-bot/app.py
@@ -6343,21 +6343,91 @@ def handle_home_integration_action(ack, body, client):
             configured = config_client.get_configured_integrations(team_id)
             existing_config = configured.get(integration_id, {})
 
-        # Use onboarding.get_integration_by_id() directly - no need for config-service schemas
-        modal = onboarding.build_integration_config_modal(
-            team_id=team_id,
-            integration_id=integration_id,
-            existing_config=existing_config,
-            entry_point="home",
-        )
+        # Check for custom flow integrations (e.g., kubernetes_saas)
+        integration_def = onboarding.get_integration_by_id(integration_id)
+        custom_flow = integration_def.get("custom_flow") if integration_def else None
 
-        client.views_open(trigger_id=body["trigger_id"], view=modal)
+        if custom_flow == "k8s_saas":
+            clusters = config_client.list_k8s_clusters(team_id)
+            modal = onboarding.build_k8s_saas_clusters_modal(
+                team_id=team_id,
+                clusters=clusters,
+                entry_point="home",
+            )
+        else:
+            # Special handling for GitHub App integration
+            if integration_id == "github" and action_type == "edit":
+                github_installation = config_client.get_linked_github_installation(
+                    team_id
+                )
+                if github_installation:
+                    if existing_config is None:
+                        existing_config = {}
+                    existing_config["github_org"] = github_installation.get(
+                        "account_login", ""
+                    )
+                    existing_config["_github_linked"] = True
+                    existing_config["_github_installation"] = github_installation
+
+            modal = onboarding.build_integration_config_modal(
+                team_id=team_id,
+                integration_id=integration_id,
+                existing_config=existing_config,
+                entry_point="home",
+            )
+
+        try:
+            client.views_open(trigger_id=body["trigger_id"], view=modal)
+        except Exception as views_err:
+            # Modal open failed — most likely due to the video block requiring
+            # the video_url domain to be registered as a Slack media domain.
+            # Retry without the video block.
+            logger.warning(
+                f"views_open failed for {integration_id}, retrying without video: {views_err}"
+            )
+            if custom_flow != "k8s_saas":
+                modal = onboarding.build_integration_config_modal(
+                    team_id=team_id,
+                    integration_id=integration_id,
+                    existing_config=existing_config,
+                    entry_point="home",
+                    include_video=False,
+                )
+                client.views_open(trigger_id=body["trigger_id"], view=modal)
+            else:
+                raise
+
         logger.info(f"Opened {action_type} modal for {integration_id} from Home Tab")
 
     except Exception as e:
         logger.error(
             f"Failed to open integration modal from Home Tab: {e}", exc_info=True
         )
+        # Show error modal so the user knows something went wrong
+        try:
+            client.views_open(
+                trigger_id=body["trigger_id"],
+                view={
+                    "type": "modal",
+                    "title": {"type": "plain_text", "text": "Error"},
+                    "close": {"type": "plain_text", "text": "Close"},
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": (
+                                    ":warning: *Could not open settings*\n\n"
+                                    "Something went wrong opening the configuration for "
+                                    f"*{integration_id}*. Please try again."
+                                ),
+                            },
+                        }
+                    ],
+                },
+            )
+        except Exception:
+            pass
 
 
 @app.action("home_book_demo")

--- a/slack-bot/onboarding.py
+++ b/slack-bot/onboarding.py
@@ -3724,6 +3724,7 @@ def build_integration_config_modal(
     integration_id: str = None,
     category_filter: str = "all",
     entry_point: str = "integrations",
+    include_video: bool = True,
 ) -> Dict[str, Any]:
     """
     Build integration configuration modal with video tutorial, instructions, and form fields.
@@ -3737,6 +3738,7 @@ def build_integration_config_modal(
         schema: Integration schema with fields definition (optional if integration_id provided)
         existing_config: Existing config values to pre-fill
         integration_id: Integration ID to look up from INTEGRATIONS
+        include_video: Whether to include the video tutorial block
 
     Returns:
         Slack modal view object
@@ -3877,7 +3879,7 @@ def build_integration_config_modal(
 
     # Video tutorial section (using Slack's video block for embedded player)
     video_config = schema.get("video")
-    if video_config:
+    if video_config and include_video:
         blocks.append(
             {
                 "type": "video",


### PR DESCRIPTION
## Description

Fixed the issue where clicking "Edit" on integration cards in the Home Tab (Grafana, Datadog, etc.) was silently failing without opening a modal. The root cause was Slack rejecting the video tutorial block when the vimeo.com domain isn't registered as a Slack media domain.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added video block fallback: if `views_open` fails, the handler retries without the video tutorial block
- Shows an error modal to the user instead of silently failing
- Added missing `kubernetes_saas` custom flow handling for K8s Agent integration
- Added GitHub App installation enrichment for edit flow (shows connected org status)
- Added `include_video` parameter to `build_integration_config_modal()` to support conditional video block inclusion

## Testing

Manual testing confirmed:
- Clicking Edit on Grafana now opens the configuration modal (falls back to non-video version if needed)
- Other integrations with Edit buttons now work correctly
- Error modal displays when configuration fails

## Deployment Notes

- [x] Backward compatible (include_video defaults to True for all existing calls)
- [x] No database changes needed
- [x] No new environment variables

## Recommended Follow-up

To fully resolve the video block issue, register these domains as Registered Media Domains in Slack app settings:
- player.vimeo.com
- vumbnail.com

This will allow the video tutorials to display inline without needing the fallback.