### PR TITLE
fix: Increase SANDBOX_TTL_MINUTES from 5 to 15 in staging

### DIFF
--- a/charts/incidentfox/values.staging.yaml
+++ b/charts/incidentfox/values.staging.yaml
@@ -263,7 +263,7 @@ services:
       - name: K8S_GATEWAY_URL
         value: "http://incidentfox-k8s-gateway.incidentfox.svc.cluster.local:8085"
       - name: SANDBOX_TTL_MINUTES
-        value: "5"
+        value: "15"
     # Enable tracing in staging for debugging
     tracing:
       enabled: true


### PR DESCRIPTION
## Description

Investigation requests with Claude SDK agents perform multi-turn reasoning and spawn subagents for analysis. The 5-minute TTL was causing sandbox pods to be killed mid-stream with ChunkedEncodingError. This PR increases the TTL to 15 minutes to allow investigation workflows to complete successfully.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes investigation timeouts in staging environment.

## Changes Made

- Increased `SANDBOX_TTL_MINUTES` from 5 to 15 minutes in `charts/incidentfox/values.staging.yaml`

## Testing

- Verified with manual investigation requests via Slack bot
- Confirmed that telemetry check requests now complete without timeout
- Tested multi-turn investigation workflow with Claude SDK agents

## Deployment Notes

- [x] Backward compatible
- Change applies to staging environment only

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)