### PR TITLE
fix: Resolve broken integrations in warm pool sandbox mode

### DIFF
--- a/charts/incidentfox/templates/sandbox-warmpool.yaml
+++ b/charts/incidentfox/templates/sandbox-warmpool.yaml
@@ -302,6 +302,22 @@ spec:
         # Coralogix SDK: route API requests through Envoy proxy
         - name: CORALOGIX_BASE_URL
           value: "http://localhost:8001"
+        # Integration URLs: route through credential-resolver's reverse proxy
+        # These are static (same service for all tenants) - JWT handles per-tenant auth
+        - name: CONFLUENCE_BASE_URL
+          value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/confluence"
+        - name: GRAFANA_BASE_URL
+          value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/grafana"
+        - name: ELASTICSEARCH_BASE_URL
+          value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/elasticsearch"
+        - name: PROMETHEUS_BASE_URL
+          value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/prometheus"
+        - name: JAEGER_BASE_URL
+          value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/jaeger"
+        - name: GITHUB_BASE_URL
+          value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/github"
+        - name: DATADOG_BASE_URL
+          value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/datadog"
         # Laminar tracing (platform observability)
         - name: LMNR_PROJECT_API_KEY
           valueFrom:

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/describe_pod.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/describe_pod.py
@@ -23,10 +23,10 @@ def get_k8s_client():
     kubeconfig = Path.home() / ".kube" / "config"
     in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
 
-    if kubeconfig.exists():
-        k8s_config.load_kube_config()
-    elif in_cluster.exists():
+    if in_cluster.exists():
         k8s_config.load_incluster_config()
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
     else:
         print(
             "Error: Kubernetes not configured. Ensure ~/.kube/config exists.",

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_events.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_events.py
@@ -26,10 +26,10 @@ def get_k8s_client():
     kubeconfig = Path.home() / ".kube" / "config"
     in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
 
-    if kubeconfig.exists():
-        k8s_config.load_kube_config()
-    elif in_cluster.exists():
+    if in_cluster.exists():
         k8s_config.load_incluster_config()
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
     else:
         print(
             "Error: Kubernetes not configured. Ensure ~/.kube/config exists.",

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_logs.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_logs.py
@@ -24,10 +24,10 @@ def get_k8s_client():
     kubeconfig = Path.home() / ".kube" / "config"
     in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
 
-    if kubeconfig.exists():
-        k8s_config.load_kube_config()
-    elif in_cluster.exists():
+    if in_cluster.exists():
         k8s_config.load_incluster_config()
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
     else:
         print(
             "Error: Kubernetes not configured. Ensure ~/.kube/config exists.",

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_resources.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/get_resources.py
@@ -26,10 +26,10 @@ def get_k8s_clients():
     kubeconfig = Path.home() / ".kube" / "config"
     in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
 
-    if kubeconfig.exists():
-        k8s_config.load_kube_config()
-    elif in_cluster.exists():
+    if in_cluster.exists():
         k8s_config.load_incluster_config()
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
     else:
         print(
             "Error: Kubernetes not configured. Ensure ~/.kube/config exists.",

--- a/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/list_pods.py
+++ b/sre-agent/.claude/skills/infrastructure-kubernetes/scripts/list_pods.py
@@ -24,10 +24,10 @@ def get_k8s_client():
     kubeconfig = Path.home() / ".kube" / "config"
     in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
 
-    if kubeconfig.exists():
-        k8s_config.load_kube_config()
-    elif in_cluster.exists():
+    if in_cluster.exists():
         k8s_config.load_incluster_config()
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
     else:
         print(
             "Error: Kubernetes not configured. Ensure ~/.kube/config exists.",

--- a/sre-agent/.claude/skills/remediation/scripts/restart_pod.py
+++ b/sre-agent/.claude/skills/remediation/scripts/restart_pod.py
@@ -26,10 +26,10 @@ def get_k8s_client():
     kubeconfig = Path.home() / ".kube" / "config"
     in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
 
-    if kubeconfig.exists():
-        k8s_config.load_kube_config()
-    elif in_cluster.exists():
+    if in_cluster.exists():
         k8s_config.load_incluster_config()
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
     else:
         print("Error: Kubernetes not configured.", file=sys.stderr)
         sys.exit(1)

--- a/sre-agent/.claude/skills/remediation/scripts/rollback_deployment.py
+++ b/sre-agent/.claude/skills/remediation/scripts/rollback_deployment.py
@@ -29,10 +29,10 @@ def get_k8s_clients():
     kubeconfig = Path.home() / ".kube" / "config"
     in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
 
-    if kubeconfig.exists():
-        k8s_config.load_kube_config()
-    elif in_cluster.exists():
+    if in_cluster.exists():
         k8s_config.load_incluster_config()
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
     else:
         print("Error: Kubernetes not configured.", file=sys.stderr)
         sys.exit(1)

--- a/sre-agent/.claude/skills/remediation/scripts/scale_deployment.py
+++ b/sre-agent/.claude/skills/remediation/scripts/scale_deployment.py
@@ -26,10 +26,10 @@ def get_k8s_client():
     kubeconfig = Path.home() / ".kube" / "config"
     in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
 
-    if kubeconfig.exists():
-        k8s_config.load_kube_config()
-    elif in_cluster.exists():
+    if in_cluster.exists():
         k8s_config.load_incluster_config()
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
     else:
         print("Error: Kubernetes not configured.", file=sys.stderr)
         sys.exit(1)

--- a/sre-agent/sandbox_server.py
+++ b/sre-agent/sandbox_server.py
@@ -160,6 +160,10 @@ async def claim_sandbox(request: ClaimRequest):
     os.environ["THREAD_ID"] = request.thread_id
     os.environ["INCIDENTFOX_TENANT_ID"] = request.tenant_id
     os.environ["INCIDENTFOX_TEAM_ID"] = request.team_id
+    # Set SANDBOX_JWT env var so scripts can use it for credential-resolver auth
+    # (Envoy Lua filter reads from file, but scripts that call credential-resolver
+    # directly need the JWT as an env var for their X-Sandbox-JWT header)
+    os.environ["SANDBOX_JWT"] = request.jwt_token
 
     print(
         f"🔑 [CLAIM] Sandbox claimed for thread {request.thread_id} "


### PR DESCRIPTION
## Summary

Fixed three root causes causing k8s, grafana, prometheus, elasticsearch, jaeger, datadog, and confluence skills to fail in warm pool sandbox mode:

1. **K8s scripts RBAC failure**: All 8 K8s scripts checked kubeconfig before in-cluster config. `kubeconfig-demo.yaml` uses `aws eks get-token` (no AWS credentials in sandbox → node role identity → RBAC denied). In-cluster SA token with proper RBAC was never reached. Fixed by checking in-cluster first.

2. **Missing integration URLs in warm pool**: Production uses `USE_WARM_POOL=true`. Warm pool template was missing 7 integration base URLs that `create_sandbox()` sets. Scripts like `grafana_client.py` raise `RuntimeError` immediately. Added all static URLs to warm pool template.

3. **Missing SANDBOX_JWT env var at claim time**: `/claim` endpoint wrote JWT to `/tmp/sandbox-jwt` (for Envoy Lua filter) but didn't set `SANDBOX_JWT` env var. Scripts calling credential-resolver directly need the JWT env var for `X-Sandbox-JWT` header. Added env var setting at claim time.

## Testing

- Manual testing with warm pool sandboxes in incidentfox-demo cluster
- Verified k8s scripts now use in-cluster SA token for auth
- Verified grafana/prometheus/etc. scripts can find base URL env vars
- Verified credential-resolver can validate JWT from env var

## Related Changes

- K8s scripts: 8 files (infrastructure-kubernetes and remediation)
- Warm pool template: 1 file (sandbox-warmpool.yaml)
- Sandbox server: 1 file (sandbox_server.py)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>