### PR TITLE
fix(slack-bot): Add slug-based OAuth redirect URL

### DIFF
--- a/slack-bot/slack-manifest.json
+++ b/slack-bot/slack-manifest.json
@@ -18,7 +18,8 @@
     },
     "oauth_config": {
         "redirect_urls": [
-            "https://slack.incidentfox.ai/slack/oauth_redirect"
+            "https://slack.incidentfox.ai/slack/oauth_redirect",
+            "https://slack.incidentfox.ai/slack/default/oauth_redirect"
         ],
         "scopes": {
             "bot": [


### PR DESCRIPTION
## Summary

Fixed the Slack OAuth installation flow by adding the slug-based redirect URL to the app manifest. When the Slack bot is registered as a multi-app installation in the config-service, it uses `/slack/default/oauth_redirect` instead of the legacy `/slack/oauth_redirect`.

## Changes Made

- Add `https://slack.incidentfox.ai/slack/default/oauth_redirect` to the Slack app manifest's OAuth redirect URLs
- Maintain `https://slack.incidentfox.ai/slack/oauth_redirect` for backward compatibility

## Testing

- ✅ Verified OAuth flow completes successfully with both redirect URLs
- ✅ Tested against production Slack app (Client ID: 9967324357443.10323403264580)
- ✅ Confirmed "default" app registered in config-service correctly

## Manual Steps

Users need to update their Slack app console:
1. Go to https://api.slack.com/apps (select IncidentFox)
2. Go to "OAuth & Permissions"
3. Add redirect URL: `https://slack.incidentfox.ai/slack/default/oauth_redirect`
4. Save URLs

## Deployment Notes

- [x] Backward compatible (legacy route still works)
- [x] No database migration required
- [x] No configuration changes needed (only Slack app console update)