### PR TITLE
fix(gchat): Google Chat Workspace Add-on compatibility fixes

### DIFF
--- a/orchestrator/src/incidentfox_orchestrator/webhooks/google_chat_app.py
+++ b/orchestrator/src/incidentfox_orchestrator/webhooks/google_chat_app.py
@@ -172,14 +172,8 @@ class GoogleChatIntegration:
             )
         )
 
-        # Return immediate response
-        response: Dict[str, Any] = {
-            "text": "IncidentFox is working on it...",
-        }
-        if thread_key:
-            response["thread"] = {"name": thread_key}
-
-        return response
+        # Return empty — the async handler sends the result as a thread reply
+        return {}
 
     async def _process_message_async(
         self,
@@ -376,9 +370,15 @@ class GoogleChatIntegration:
                 )
                 return
 
-            # Parse key if it's a JSON string
+            # Parse key — may be raw JSON, base64-encoded JSON, or a dict
             if isinstance(sa_key_json, str):
-                sa_key_info = json.loads(sa_key_json)
+                try:
+                    sa_key_info = json.loads(sa_key_json)
+                except json.JSONDecodeError:
+                    # Try base64 decode
+                    import base64
+
+                    sa_key_info = json.loads(base64.b64decode(sa_key_json))
             else:
                 sa_key_info = sa_key_json
 

--- a/orchestrator/src/incidentfox_orchestrator/webhooks/router.py
+++ b/orchestrator/src/incidentfox_orchestrator/webhooks/router.py
@@ -2141,11 +2141,16 @@ async def google_chat_webhook(
         )
 
     # Verify JWT
-    google_chat_project_id = os.getenv("GOOGLE_CHAT_PROJECT_ID", "").strip()
+    # Google Chat HTTP endpoints use the webhook URL as the JWT audience.
+    # Behind TLS-terminating LB, request.url is http:// but the token uses https://
+    url = str(request.url)
+    if request.headers.get("x-forwarded-proto") == "https" and url.startswith("http://"):
+        url = "https://" + url[len("http://"):]
+    expected_audience = os.getenv("GOOGLE_CHAT_AUDIENCE", "").strip() or url
     try:
         verify_google_chat_bearer_token(
             authorization=authorization or None,
-            expected_audience=google_chat_project_id,
+            expected_audience=expected_audience,
         )
     except SignatureVerificationError as e:
         _log("google_chat_auth_failed", reason=e.reason)
@@ -2158,7 +2163,50 @@ async def google_chat_webhook(
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="invalid_json")
 
-    event_type = payload.get("type", "")
+    # Google Chat sends different payload formats:
+    # - Legacy/Chat app: {"type": "MESSAGE", "message": {...}, "space": {...}}
+    # - Workspace Add-on: {"commonEventObject": {...}, "chat": {
+    #       "messagePayload": {"message": {...}, "space": {...}},
+    #       "user": {...}, "eventTime": "..."
+    #   }}
+    # Normalize to legacy format for downstream handlers
+    chat_data = payload.get("chat", {}) or {}
+    event_type = payload.get("type", "") or payload.get("eventType", "")
+
+    if not event_type and chat_data:
+        # Workspace Add-on format — infer event type from payload keys
+        if "messagePayload" in chat_data:
+            event_type = "MESSAGE"
+            # Unwrap: chat.messagePayload contains {message, space}
+            msg_payload = chat_data["messagePayload"]
+            event_data = {
+                "type": "MESSAGE",
+                "message": msg_payload.get("message", {}),
+                "space": msg_payload.get("space", {}),
+                "user": chat_data.get("user", {}),
+                "eventTime": chat_data.get("eventTime", ""),
+            }
+        elif "addedToSpacePayload" in chat_data:
+            event_type = "ADDED_TO_SPACE"
+            space_payload = chat_data["addedToSpacePayload"]
+            event_data = {
+                "type": "ADDED_TO_SPACE",
+                "space": space_payload.get("space", {}),
+                "user": chat_data.get("user", {}),
+            }
+        elif "removedFromSpacePayload" in chat_data:
+            event_type = "REMOVED_FROM_SPACE"
+            space_payload = chat_data["removedFromSpacePayload"]
+            event_data = {
+                "type": "REMOVED_FROM_SPACE",
+                "space": space_payload.get("space", {}),
+                "user": chat_data.get("user", {}),
+            }
+        else:
+            event_data = payload
+    else:
+        event_data = payload
+
     correlation_id = __import__("uuid").uuid4().hex
 
     _log(
@@ -2168,11 +2216,24 @@ async def google_chat_webhook(
     )
 
     # Handle event and return response
+    is_addon_format = bool(chat_data)
     response = await gchat_integration.handle_event(
         event_type=event_type,
-        event_data=payload,
+        event_data=event_data,
         correlation_id=correlation_id,
     )
+
+    # Workspace Add-on format requires wrapping the response
+    if is_addon_format and response.get("text"):
+        response = {
+            "hostAppDataAction": {
+                "chatDataAction": {
+                    "createMessageAction": {
+                        "message": response,
+                    }
+                }
+            }
+        }
 
     return JSONResponse(content=response)
 

--- a/orchestrator/src/incidentfox_orchestrator/webhooks/signatures.py
+++ b/orchestrator/src/incidentfox_orchestrator/webhooks/signatures.py
@@ -475,8 +475,11 @@ def verify_google_chat_bearer_token(
         )
 
         # Verify issuer is Google Chat
+        # HTTP endpoint apps use "https://accounts.google.com" as issuer
+        # Apps Script/Cloud Function apps use "chat@system.gserviceaccount.com"
+        valid_issuers = {"chat@system.gserviceaccount.com", "https://accounts.google.com"}
         issuer = claims.get("iss", "")
-        if issuer != "chat@system.gserviceaccount.com":
+        if issuer not in valid_issuers:
             raise SignatureVerificationError(
                 f"invalid_issuer (got {issuer})", "google_chat"
             )


### PR DESCRIPTION
## Summary
- Use request URL as JWT audience with X-Forwarded-Proto upgrade for TLS termination
- Accept both `https://accounts.google.com` and `chat@system.gserviceaccount.com` as valid JWT issuers
- Parse Workspace Add-on payload format (`chat.messagePayload`) and normalize to legacy format
- Wrap sync responses in `hostAppDataAction.chatDataAction.createMessageAction` envelope
- Return empty sync response to avoid duplicate threads (async handler replies to original thread)
- Add base64 decode fallback for service account key parsing

## Test plan
- [x] Tested end-to-end: @mention bot in Google Chat space, bot receives message and replies in thread
- [x] Verified JWT auth works with both HTTP endpoint (accounts.google.com) and legacy issuers
- [x] Verified no duplicate threads created from sync response

🤖 Generated with [Claude Code](https://claude.com/claude-code)