### PR TITLE
feat(gchat): Send 'working on it' reply in the original thread

### DIFF
--- a/orchestrator/src/incidentfox_orchestrator/webhooks/google_chat_app.py
+++ b/orchestrator/src/incidentfox_orchestrator/webhooks/google_chat_app.py
@@ -172,8 +172,11 @@ class GoogleChatIntegration:
             )
         )
 
-        # Return empty — the async handler sends the result as a thread reply
-        return {}
+        # Immediate "working on it" reply in the same thread
+        reply: Dict[str, Any] = {"text": "IncidentFox is working on it..."}
+        if thread_key:
+            reply["thread"] = {"name": thread_key}
+        return reply
 
     async def _process_message_async(
         self,


### PR DESCRIPTION
## Summary
- Return an immediate sync response with thread info so the bot acknowledges the message in the same thread before async processing completes

## Test plan
- [ ] @mention bot in Google Chat space, verify "IncidentFox is working on it..." appears in the same thread
- [ ] Verify the async result also replies in the same thread (no duplicate threads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)