### PR TITLE
fix: Add prod Terraform env with 50GB disk for RAG nodes

### DIFF
--- a/infra/terraform/envs/prod/alarms.tf
+++ b/infra/terraform/envs/prod/alarms.tf
@@ -1,0 +1,351 @@
+locals {
+  cw_region        = var.aws_region
+  cw_cluster_name  = var.cluster_name
+  cw_alarm_prefix  = "${var.cluster_name}"
+  cw_log_namespace = "IncidentFox"
+
+  # Container Insights log group where app logs land (JSON logs from pods)
+  cw_app_log_group = "/aws/containerinsights/${var.cluster_name}/application"
+
+  # Optional: send alarm notifications to SNS (used by AWS Chatbot)
+  cw_alarm_actions = var.enable_chatbot_slack ? [aws_sns_topic.incidentfox_alerts.arn] : []
+}
+
+#
+# Inputs for infra-level alarm dimensions.
+#
+# We intentionally keep these as variables so the team can review/change and so
+# Terraform doesn't need to “discover” k8s-managed resources.
+#
+variable "alb_load_balancer_dimension" {
+  type        = string
+  description = "CloudWatch dimension value for ALB alarms (the 'app/..../....' suffix, not the full ARN). Example: app/k8s-incident-incident-bb9f18348b/3e9b1a1acbca10a1"
+  default     = ""
+}
+
+variable "rds_instance_identifier" {
+  type        = string
+  description = "RDS DBInstanceIdentifier for alarms."
+  default     = "incidentfox-prod"
+}
+
+#
+# -----------------
+# ALB (Web UI) alarms
+# -----------------
+#
+resource "aws_cloudwatch_metric_alarm" "alb_5xx" {
+  alarm_name          = "${local.cw_alarm_prefix}-alb-5xx"
+  alarm_description   = "ALB 5xx detected"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    LoadBalancer = var.alb_load_balancer_dimension
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_target_5xx" {
+  alarm_name          = "${local.cw_alarm_prefix}-alb-target-5xx"
+  alarm_description   = "Targets returning 5xx"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 5
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    LoadBalancer = var.alb_load_balancer_dimension
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_p95_latency" {
+  alarm_name          = "${local.cw_alarm_prefix}-alb-p95-latency"
+  alarm_description   = "p95 target response time too high"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "TargetResponseTime"
+  extended_statistic  = "p95"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 2
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    LoadBalancer = var.alb_load_balancer_dimension
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_unhealthy_targets" {
+  alarm_name          = "${local.cw_alarm_prefix}-alb-unhealthy-targets"
+  alarm_description   = "Unhealthy targets > 0"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "UnHealthyHostCount"
+  statistic           = "Maximum"
+  period              = 60
+  evaluation_periods  = 3
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    LoadBalancer = var.alb_load_balancer_dimension
+  }
+}
+
+#
+# -----------------
+# RDS alarms
+# -----------------
+#
+resource "aws_cloudwatch_metric_alarm" "rds_cpu_high" {
+  alarm_name          = "${local.cw_alarm_prefix}-rds-cpu-high"
+  alarm_description   = "RDS CPU > 80%"
+  namespace           = "AWS/RDS"
+  metric_name         = "CPUUtilization"
+  statistic           = "Average"
+  period              = 60
+  evaluation_periods  = 10
+  threshold           = 80
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_identifier
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_free_storage_low" {
+  alarm_name          = "${local.cw_alarm_prefix}-rds-free-storage-low"
+  alarm_description   = "RDS free storage < 10GB"
+  namespace           = "AWS/RDS"
+  metric_name         = "FreeStorageSpace"
+  statistic           = "Minimum"
+  period              = 300
+  evaluation_periods  = 2
+  threshold           = 10737418240 # 10GiB in bytes
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_identifier
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_free_mem_low" {
+  alarm_name          = "${local.cw_alarm_prefix}-rds-free-mem-low"
+  alarm_description   = "RDS freeable memory low (<512MiB)"
+  namespace           = "AWS/RDS"
+  metric_name         = "FreeableMemory"
+  statistic           = "Minimum"
+  period              = 60
+  evaluation_periods  = 10
+  threshold           = 536870912 # 512MiB
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_identifier
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_connections_high" {
+  alarm_name          = "${local.cw_alarm_prefix}-rds-connections-high"
+  alarm_description   = "RDS connections > 200"
+  namespace           = "AWS/RDS"
+  metric_name         = "DatabaseConnections"
+  statistic           = "Maximum"
+  period              = 60
+  evaluation_periods  = 10
+  threshold           = 200
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_identifier
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_write_latency_high" {
+  alarm_name          = "${local.cw_alarm_prefix}-rds-latency-write"
+  alarm_description   = "RDS write latency high (>50ms)"
+  namespace           = "AWS/RDS"
+  metric_name         = "WriteLatency"
+  statistic           = "Average"
+  period              = 60
+  evaluation_periods  = 10
+  threshold           = 0.05
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_identifier
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_read_latency_high" {
+  alarm_name          = "${local.cw_alarm_prefix}-rds-latency-read"
+  alarm_description   = "RDS read latency high (>50ms)"
+  namespace           = "AWS/RDS"
+  metric_name         = "ReadLatency"
+  statistic           = "Average"
+  period              = 60
+  evaluation_periods  = 10
+  threshold           = 0.05
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_identifier
+  }
+}
+
+#
+# -----------------
+# App-level alarms from log metric filters (JSON structured logs)
+# -----------------
+#
+resource "aws_cloudwatch_log_metric_filter" "slack_trigger_failed" {
+  name           = "${local.cw_alarm_prefix}-slack-trigger-failed"
+  log_group_name = local.cw_app_log_group
+  pattern        = "{ $.event = \"slack_trigger_run_failed\" }"
+
+  metric_transformation {
+    name          = "slack_trigger_failed"
+    namespace     = local.cw_log_namespace
+    value         = "1"
+    default_value = 0
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "slack_post_failed" {
+  name           = "${local.cw_alarm_prefix}-slack-post-failed"
+  log_group_name = local.cw_app_log_group
+  pattern        = "{ $.event = \"slack_post_failed\" }"
+
+  metric_transformation {
+    name          = "slack_post_failed"
+    namespace     = local.cw_log_namespace
+    value         = "1"
+    default_value = 0
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "agent_upstream_error" {
+  name           = "${local.cw_alarm_prefix}-agent-upstream-error"
+  log_group_name = local.cw_app_log_group
+  pattern        = "agent_upstream_error"
+
+  metric_transformation {
+    name          = "agent_upstream_error"
+    namespace     = local.cw_log_namespace
+    value         = "1"
+    default_value = 0
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "slack_trigger_failed_alarm" {
+  alarm_name          = "${local.cw_alarm_prefix}-slack-trigger-failed"
+  alarm_description   = "Slack trigger runs failing"
+  namespace           = local.cw_log_namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.slack_trigger_failed.metric_transformation[0].name
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+}
+
+resource "aws_cloudwatch_metric_alarm" "slack_post_failed_alarm" {
+  alarm_name          = "${local.cw_alarm_prefix}-slack-post-failed"
+  alarm_description   = "Slack postMessage failures"
+  namespace           = local.cw_log_namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.slack_post_failed.metric_transformation[0].name
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+}
+
+resource "aws_cloudwatch_metric_alarm" "agent_upstream_error_alarm" {
+  alarm_name          = "${local.cw_alarm_prefix}-agent-upstream-error"
+  alarm_description   = "Orchestrator/agent upstream errors"
+  namespace           = local.cw_log_namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.agent_upstream_error.metric_transformation[0].name
+  statistic           = "Sum"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+}
+
+#
+# -----------------
+# Container Insights alarms (Kubernetes)
+# -----------------
+#
+resource "aws_cloudwatch_metric_alarm" "k8s_pods_not_running" {
+  alarm_name          = "${local.cw_alarm_prefix}-k8s-pods-not-running"
+  alarm_description   = "Pods not running (namespace incidentfox)"
+  namespace           = "ContainerInsights"
+  metric_name         = "pod_container_status_running"
+  statistic           = "Minimum"
+  period              = 60
+  evaluation_periods  = 5
+  threshold           = 1
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    ClusterName = local.cw_cluster_name
+    Namespace   = "incidentfox"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "k8s_restarts" {
+  alarm_name          = "${local.cw_alarm_prefix}-k8s-restarts"
+  alarm_description   = "Container restarts detected (namespace incidentfox)"
+  namespace           = "ContainerInsights"
+  metric_name         = "pod_number_of_container_restarts"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.cw_alarm_actions
+
+  dimensions = {
+    ClusterName = local.cw_cluster_name
+    Namespace   = "incidentfox"
+  }
+}
+
+

--- a/infra/terraform/envs/prod/chatbot.tf
+++ b/infra/terraform/envs/prod/chatbot.tf
@@ -1,0 +1,130 @@
+#
+# Slack paging via AWS Chatbot
+#
+# AWS Chatbot itself is free, but SNS + CloudWatch usage may incur small AWS charges depending on volume.
+#
+
+variable "enable_chatbot_slack" {
+  type        = bool
+  description = "If true, create an AWS Chatbot Slack channel configuration and wire alarms to SNS."
+  default     = false
+}
+
+variable "slack_team_id" {
+  type        = string
+  description = "Slack workspace/team ID (starts with T...). Required when enable_chatbot_slack=true."
+  default     = ""
+}
+
+variable "slack_channel_id" {
+  type        = string
+  description = "Slack channel ID (starts with C...). Required when enable_chatbot_slack=true."
+  default     = ""
+}
+
+resource "aws_sns_topic" "incidentfox_alerts" {
+  name = "${var.cluster_name}-alerts"
+  tags = local.tags
+}
+
+# Allow CloudWatch Alarms to publish to the SNS topic
+resource "aws_sns_topic_policy" "incidentfox_alerts" {
+  arn = aws_sns_topic.incidentfox_alerts.arn
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "AllowCloudWatchAlarmsPublish",
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudwatch.amazonaws.com"
+        },
+        Action   = "sns:Publish",
+        Resource = aws_sns_topic.incidentfox_alerts.arn
+      }
+    ]
+  })
+}
+
+# Chatbot needs an IAM role
+resource "aws_iam_role" "chatbot" {
+  count = var.enable_chatbot_slack ? 1 : 0
+  name  = "incidentfox-${var.environment}-chatbot"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "chatbot.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "chatbot_inline" {
+  count = var.enable_chatbot_slack ? 1 : 0
+  name  = "incidentfox-${var.environment}-chatbot-inline"
+  role  = aws_iam_role.chatbot[0].id
+
+  # Minimal policy for SNS -> Slack notifications:
+  # allow AWS Chatbot to manage subscriptions to the alerts topic.
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "AllowSnsSubscribeToAlertsTopic",
+        Effect = "Allow",
+        Action = [
+          "sns:GetTopicAttributes",
+          "sns:ListSubscriptionsByTopic",
+          "sns:Subscribe",
+          "sns:Unsubscribe"
+        ],
+        Resource = aws_sns_topic.incidentfox_alerts.arn
+      },
+      # Optional read-only (useful if later you enable Chatbot AWS commands in Slack).
+      {
+        Sid    = "AllowReadOnlyCloudWatchForContext",
+        Effect = "Allow",
+        Action = [
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:DescribeAlarmHistory",
+          "cloudwatch:GetMetricData",
+          "cloudwatch:GetMetricStatistics",
+          "cloudwatch:ListMetrics"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_chatbot_slack_channel_configuration" "incidentfox_alerts" {
+  count = var.enable_chatbot_slack ? 1 : 0
+
+  configuration_name = "${var.cluster_name}-alerts"
+  iam_role_arn       = aws_iam_role.chatbot[0].arn
+
+  # AWS provider uses slack_team_id for the workspace/team identifier.
+  slack_team_id    = var.slack_team_id
+  slack_channel_id   = var.slack_channel_id
+
+  sns_topic_arns = [aws_sns_topic.incidentfox_alerts.arn]
+
+  logging_level = "ERROR"
+
+  lifecycle {
+    precondition {
+      condition     = length(trimspace(var.slack_team_id)) > 0 && length(trimspace(var.slack_channel_id)) > 0
+      error_message = "When enable_chatbot_slack=true you must set slack_team_id (T...) and slack_channel_id (C...)."
+    }
+  }
+
+  tags = local.tags
+}
+
+

--- a/infra/terraform/envs/prod/main.tf
+++ b/infra/terraform/envs/prod/main.tf
@@ -1,0 +1,357 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  # Remote state is enterprise-default. `scripts/incidentfoxctl.py` passes backend config
+  # (bucket/key/region/dynamodb_table) via `terraform init -backend-config=...`.
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+}
+
+locals {
+  tags = merge(var.tags, { Environment = var.environment })
+}
+
+# Optional: create ECR repos (pilot helper).
+module "ecr" {
+  count  = var.create_ecr ? 1 : 0
+  source = "../../modules/ecr"
+
+  name_prefix  = "incidentfox-${var.environment}"
+  repositories = var.ecr_repositories
+  force_delete = var.ecr_force_delete
+  tags         = local.tags
+}
+
+# Optional: create a VPC (pilot helper). Enterprises can BYO VPC/subnets instead.
+module "vpc" {
+  count  = var.create_vpc ? 1 : 0
+  source = "../../modules/vpc"
+
+  name               = "incidentfox-${var.environment}"
+  cidr               = var.vpc_cidr
+  azs                = var.vpc_azs
+  public_subnets     = var.vpc_public_subnets
+  private_subnets    = var.vpc_private_subnets
+  single_nat_gateway = var.vpc_single_nat_gateway
+  tags               = local.tags
+}
+
+locals {
+  effective_vpc_id             = var.create_vpc ? module.vpc[0].vpc_id : var.vpc_id
+  effective_private_subnet_ids = var.create_vpc ? module.vpc[0].private_subnet_ids : var.private_subnet_ids
+}
+
+# Optional: create an EKS cluster
+module "eks" {
+  count  = var.create_eks ? 1 : 0
+  source = "../../modules/eks"
+
+  cluster_name        = var.cluster_name
+  cluster_version     = var.cluster_version
+  cluster_endpoint_public_access       = var.cluster_endpoint_public_access
+  cluster_endpoint_private_access      = var.cluster_endpoint_private_access
+  cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
+  vpc_id              = local.effective_vpc_id
+  private_subnet_ids  = local.effective_private_subnet_ids
+  node_instance_types = var.node_instance_types
+  node_ami_type       = var.node_ami_type
+  node_min_size       = var.node_min_size
+  node_max_size       = var.node_max_size
+  node_desired_size   = var.node_desired_size
+
+  # Memory-intensive node group for RAG workloads
+  memory_intensive_nodegroup_enabled = var.memory_intensive_nodegroup_enabled
+  memory_intensive_instance_types    = var.memory_intensive_instance_types
+  memory_intensive_disk_size         = var.memory_intensive_disk_size
+  memory_intensive_min_size          = var.memory_intensive_min_size
+  memory_intensive_max_size          = var.memory_intensive_max_size
+  memory_intensive_desired_size      = var.memory_intensive_desired_size
+
+  tags                = local.tags
+}
+
+locals {
+  oidc_provider_arn = var.create_eks ? module.eks[0].cluster_oidc_provider_arn : var.eks_oidc_provider_arn
+  effective_node_sg = var.create_eks ? module.eks[0].node_security_group_id : var.eks_node_security_group_id
+}
+
+# IAM/IRSA for controllers
+module "iam_irsa" {
+  source              = "../../modules/iam_irsa"
+  name_prefix         = "incidentfox-${var.environment}"
+  oidc_provider_arn   = local.oidc_provider_arn
+  secrets_manager_arns = var.eso_allowed_secret_arns
+  tags                = local.tags
+}
+
+# IAM/IRSA for the IncidentFox agent (read-only AWS inspection tools)
+data "aws_iam_openid_connect_provider" "eks" {
+  arn = local.oidc_provider_arn
+}
+
+locals {
+  agent_namespace            = "incidentfox-prod"
+  agent_service_account_name = "incidentfox-agent"
+}
+
+resource "aws_iam_role" "agent" {
+  name = "incidentfox-${var.environment}-agent"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = { Federated = local.oidc_provider_arn },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${replace(data.aws_iam_openid_connect_provider.eks.url, "https://", "")}:sub" = "system:serviceaccount:${local.agent_namespace}:${local.agent_service_account_name}"
+          }
+        }
+      }
+    ]
+  })
+  tags = local.tags
+}
+
+resource "aws_iam_policy" "agent_readonly" {
+  name = "incidentfox-${var.environment}-agent-readonly"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "sts:GetCallerIdentity",
+
+          "ec2:Describe*",
+          "tag:GetResources",
+
+          "rds:Describe*",
+          "rds:ListTagsForResource",
+
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:FilterLogEvents",
+          "logs:StartQuery",
+          "logs:GetQueryResults",
+
+          "cloudwatch:GetMetricData",
+          "cloudwatch:GetMetricStatistics",
+          "cloudwatch:ListMetrics",
+          "cloudwatch:DescribeAlarms",
+
+          "lambda:GetFunction",
+          "lambda:ListFunctions",
+
+          "ecs:ListClusters",
+          "ecs:DescribeClusters",
+          "ecs:ListServices",
+          "ecs:DescribeServices",
+          "ecs:ListTasks",
+          "ecs:DescribeTasks"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "agent_readonly_attach" {
+  role       = aws_iam_role.agent.name
+  policy_arn = aws_iam_policy.agent_readonly.arn
+}
+
+# IAM/IRSA for CloudWatch Observability (logs + Container Insights metrics)
+locals {
+  cloudwatch_namespace = "amazon-cloudwatch"
+}
+
+resource "aws_iam_role" "cloudwatch_observability" {
+  name = "incidentfox-${var.environment}-cloudwatch-observability"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = { Federated = local.oidc_provider_arn },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${replace(data.aws_iam_openid_connect_provider.eks.url, "https://", "")}:sub" = "system:serviceaccount:${local.cloudwatch_namespace}:cloudwatch-agent"
+          }
+        }
+      },
+      {
+        Effect = "Allow",
+        Principal = { Federated = local.oidc_provider_arn },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${replace(data.aws_iam_openid_connect_provider.eks.url, "https://", "")}:sub" = "system:serviceaccount:${local.cloudwatch_namespace}:fluent-bit"
+          }
+        }
+      }
+    ]
+  })
+  tags = local.tags
+}
+
+resource "aws_iam_policy" "cloudwatch_observability" {
+  name = "incidentfox-${var.environment}-cloudwatch-observability"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          # Logs
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:PutLogEvents",
+          "logs:PutRetentionPolicy",
+
+          # Metrics (Container Insights / custom PutMetricData)
+          "cloudwatch:PutMetricData",
+
+          # Needed for metadata enrichment
+          "ec2:DescribeTags",
+          "ec2:DescribeInstances",
+          "ec2:DescribeRegions",
+
+          # For cluster metadata
+          "eks:DescribeCluster"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_observability_attach" {
+  role       = aws_iam_role.cloudwatch_observability.name
+  policy_arn = aws_iam_policy.cloudwatch_observability.arn
+}
+
+# Optional: create RDS
+module "rds" {
+  count  = var.create_rds ? 1 : 0
+  source = "../../modules/rds"
+
+  name                     = "incidentfox-${var.environment}"
+  vpc_id                    = local.effective_vpc_id
+  subnet_ids                = local.effective_private_subnet_ids
+  allowed_security_group_id = local.effective_node_sg
+  db_name                   = var.db_name
+  db_username               = var.db_username
+  db_password               = local.effective_db_password
+  backup_retention_days     = var.rds_backup_retention_days
+  deletion_protection       = var.rds_deletion_protection
+  tags                      = local.tags
+}
+
+#
+# Secrets (prod): keep everything in AWS Secrets Manager and let ESO sync into the cluster.
+# - We generate DB password + config_service internal secrets.
+# - We intentionally DO NOT set the OpenAI key here; populate it once in Secrets Manager.
+#
+
+resource "random_password" "db_password" {
+  length  = 32
+  special = true
+}
+
+resource "random_password" "config_admin_token" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "token_pepper" {
+  length  = 32
+  special = true
+}
+
+resource "random_password" "impersonation_jwt_secret" {
+  length  = 48
+  special = true
+}
+
+locals {
+  effective_db_password = length(trimspace(var.db_password)) > 0 ? var.db_password : random_password.db_password.result
+  database_url = var.create_rds ? format(
+    "postgresql+psycopg://%s:%s@%s:5432/%s",
+    var.db_username,
+    local.effective_db_password,
+    module.rds[0].db_endpoint,
+    var.db_name
+  ) : ""
+}
+
+resource "aws_secretsmanager_secret" "database_url" {
+  name = "incidentfox/prod/database_url"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "database_url" {
+  secret_id     = aws_secretsmanager_secret.database_url.id
+  secret_string = local.database_url
+  depends_on    = [module.rds]
+}
+
+resource "aws_secretsmanager_secret" "config_service_admin_token" {
+  name = "incidentfox/prod/config_service_admin_token"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "config_service_admin_token" {
+  secret_id     = aws_secretsmanager_secret.config_service_admin_token.id
+  secret_string = random_password.config_admin_token.result
+}
+
+resource "aws_secretsmanager_secret" "config_service_token_pepper" {
+  name = "incidentfox/prod/config_service_token_pepper"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "config_service_token_pepper" {
+  secret_id     = aws_secretsmanager_secret.config_service_token_pepper.id
+  secret_string = random_password.token_pepper.result
+}
+
+resource "aws_secretsmanager_secret" "config_service_impersonation_jwt_secret" {
+  name = "incidentfox/prod/config_service_impersonation_jwt_secret"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "config_service_impersonation_jwt_secret" {
+  secret_id     = aws_secretsmanager_secret.config_service_impersonation_jwt_secret.id
+  secret_string = random_password.impersonation_jwt_secret.result
+}
+
+resource "aws_secretsmanager_secret" "openai_api_key" {
+  name = "incidentfox/prod/openai_api_key"
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "openai_api_key" {
+  secret_id     = aws_secretsmanager_secret.openai_api_key.id
+  # Placeholder so ESO can sync a value. Replace via Secrets Manager before using the agent.
+  secret_string = "REPLACE_ME"
+}

--- a/infra/terraform/envs/prod/outputs.tf
+++ b/infra/terraform/envs/prod/outputs.tf
@@ -1,0 +1,53 @@
+output "alb_controller_role_arn" {
+  value = module.iam_irsa.alb_controller_role_arn
+}
+
+output "external_secrets_role_arn" {
+  value = module.iam_irsa.external_secrets_role_arn
+}
+
+output "agent_role_arn" {
+  value = aws_iam_role.agent.arn
+}
+
+output "cloudwatch_observability_role_arn" {
+  value = aws_iam_role.cloudwatch_observability.arn
+}
+
+output "alerts_sns_topic_arn" {
+  value = aws_sns_topic.incidentfox_alerts.arn
+}
+
+output "ecr_repository_urls" {
+  value = try(module.ecr[0].repository_urls, null)
+}
+
+output "eks_cluster_name" {
+  value = try(module.eks[0].cluster_name, null)
+}
+
+output "eks_node_security_group_id" {
+  value = try(module.eks[0].node_security_group_id, null)
+}
+
+output "vpc_id" {
+  value = try(module.vpc[0].vpc_id, null)
+}
+
+output "private_subnet_ids" {
+  value = try(module.vpc[0].private_subnet_ids, null)
+}
+
+output "rds_endpoint" {
+  value = try(module.rds[0].db_endpoint, null)
+}
+
+output "prod_secrets" {
+  value = {
+    database_url                         = "incidentfox/prod/database_url"
+    config_service_admin_token           = "incidentfox/prod/config_service_admin_token"
+    config_service_token_pepper          = "incidentfox/prod/config_service_token_pepper"
+    config_service_impersonation_jwt_secret = "incidentfox/prod/config_service_impersonation_jwt_secret"
+    openai_api_key                       = "incidentfox/prod/openai_api_key"
+  }
+}

--- a/infra/terraform/envs/prod/variables.tf
+++ b/infra/terraform/envs/prod/variables.tf
@@ -1,0 +1,233 @@
+variable "environment" {
+  type    = string
+  default = "prod"
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "aws_profile" {
+  type    = string
+  default = ""
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+# Optional: create ECR repos (pilot helper). Enterprises can use their own registry.
+variable "create_ecr" {
+  type    = bool
+  default = true
+}
+
+variable "ecr_repositories" {
+  type    = list(string)
+  default = ["config-service", "orchestrator", "ai-pipeline-api", "agent", "web-ui"]
+}
+
+variable "ecr_force_delete" {
+  type    = bool
+  default = false
+}
+
+# Network (required in both BYO and create modes)
+variable "vpc_id" {
+  type    = string
+  default = ""
+}
+
+variable "private_subnet_ids" {
+  type    = list(string)
+  default = []
+}
+
+# VPC mode (optional helper for pilot stacks)
+variable "create_vpc" {
+  type    = bool
+  default = false
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.42.0.0/16"
+}
+
+variable "vpc_azs" {
+  type        = list(string)
+  description = "Optional AZ list. If empty, module uses provider-available AZs."
+  default     = []
+}
+
+variable "vpc_public_subnets" {
+  type    = list(string)
+  default = ["10.42.0.0/20", "10.42.16.0/20", "10.42.32.0/20"]
+}
+
+variable "vpc_private_subnets" {
+  type    = list(string)
+  default = ["10.42.128.0/20", "10.42.144.0/20", "10.42.160.0/20"]
+}
+
+variable "vpc_single_nat_gateway" {
+  type    = bool
+  default = true
+}
+
+# EKS mode
+variable "create_eks" {
+  type    = bool
+  default = false
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "incidentfox-prod"
+}
+
+variable "cluster_version" {
+  type    = string
+  default = "1.30"
+}
+
+variable "cluster_endpoint_public_access" {
+  type    = bool
+  default = false
+}
+
+variable "cluster_endpoint_private_access" {
+  type    = bool
+  default = true
+}
+
+variable "cluster_endpoint_public_access_cidrs" {
+  type    = list(string)
+  default = []
+}
+
+variable "eks_oidc_provider_arn" {
+  type        = string
+  default     = ""
+  description = "If BYO EKS, provide OIDC provider ARN"
+}
+
+variable "node_instance_types" {
+  type    = list(string)
+  default = ["m7g.large"]
+}
+
+variable "node_ami_type" {
+  type        = string
+  description = "EKS managed node group AMI type"
+  default     = "AL2023_ARM_64_STANDARD"
+}
+
+variable "node_min_size" {
+  type    = number
+  default = 1
+}
+
+variable "node_max_size" {
+  type    = number
+  default = 4
+}
+
+variable "node_desired_size" {
+  type    = number
+  default = 2
+}
+
+variable "eks_node_security_group_id" {
+  type        = string
+  default     = ""
+  description = "Security group to allow DB ingress from (BYO EKS cluster SG or node SG)"
+}
+
+# Memory-intensive node group for RAG/knowledge-base workloads
+variable "memory_intensive_nodegroup_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable memory-intensive node group for RAG workloads"
+}
+
+variable "memory_intensive_instance_types" {
+  type        = list(string)
+  default     = ["r6i.xlarge"]
+  description = "Instance types for memory-intensive nodegroup (32GB RAM for RAG trees + rolling updates)"
+}
+
+variable "memory_intensive_disk_size" {
+  type        = number
+  default     = 50
+  description = "Disk size in GB for memory-intensive nodes"
+}
+
+variable "memory_intensive_min_size" {
+  type    = number
+  default = 0
+}
+
+variable "memory_intensive_max_size" {
+  type    = number
+  default = 2
+}
+
+variable "memory_intensive_desired_size" {
+  type    = number
+  default = 1
+}
+
+# ESO permissions
+variable "eso_allowed_secret_arns" {
+  type        = list(string)
+  default     = ["*"]
+  description = "Secrets Manager ARNs ESO is allowed to read (restrict in real enterprise deployments)"
+}
+
+# RDS mode
+variable "create_rds" {
+  type    = bool
+  default = false
+}
+
+variable "db_name" {
+  type    = string
+  default = "incidentfox"
+}
+
+variable "db_username" {
+  type    = string
+  default = "incidentfox"
+}
+
+variable "db_password" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "rds_backup_retention_days" {
+  type    = number
+  default = 7
+}
+
+variable "rds_deletion_protection" {
+  type    = bool
+  default = true
+}
+
+locals {
+  _byo_network_ok = var.create_vpc || (length(trimspace(var.vpc_id)) > 0 && length(var.private_subnet_ids) > 0)
+}
+
+resource "terraform_data" "validate_inputs" {
+  lifecycle {
+    precondition {
+      condition     = local._byo_network_ok
+      error_message = "You must either set create_vpc=true OR provide vpc_id and private_subnet_ids."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- The `incidentfox-ultimate-rag` pod on `incidentfox-prod` is in an infinite eviction loop due to **DiskPressure** — the `memory-intensive-nodes-r6i` node group was created with **20 GB** disk while demo has **50 GB**
- The 4.3 GB Docker image + 3 GB tree download + OS overhead exceeds 20 GB, triggering kubelet evictions
- Adds a `infra/terraform/envs/prod/` environment mirroring `pilot` with the correct `memory_intensive_disk_size = 50` default and prod-hardened settings (`rds_deletion_protection = true`, `ecr_force_delete = false`, `rds_backup_retention_days = 7`)

## Post-merge: recreate the node group

EKS doesn't allow in-place disk size changes. After merging, the node group must be recreated:

```bash
# 1. Create new node group with 50GB disk
aws eks create-nodegroup \
  --cluster-name incidentfox-prod \
  --nodegroup-name memory-intensive-nodes-r6i-v2 \
  --instance-types r6i.xlarge \
  --disk-size 50 \
  --scaling-config minSize=0,maxSize=2,desiredSize=1 \
  --labels workload=memory-intensive \
  --node-role <arn-from-existing-nodegroup> \
  --subnets <subnets-from-existing-nodegroup> \
  --region us-west-2

# 2. Wait for new node group ACTIVE
# 3. Cordon + drain old node
# 4. Delete old node group
aws eks delete-nodegroup \
  --cluster-name incidentfox-prod \
  --nodegroup-name memory-intensive-nodes-r6i \
  --region us-west-2
```

## Test plan

- [x] `terraform validate` passes
- [ ] Diff `prod/variables.tf` vs `pilot/variables.tf` — only intentional changes
- [ ] After node group recreation: verify ultimate-rag pod starts without eviction

🤖 Generated with [Claude Code](https://claude.com/claude-code)