### PR TITLE
fix(sre-agent): Pass images and files through in simple mode

### DIFF
--- a/sre-agent/server_simple.py
+++ b/sre-agent/server_simple.py
@@ -271,7 +271,9 @@ def _download_file_attachments(file_downloads: list):
             counter += 1
 
         try:
-            logger.info(f"Downloading {safe_filename} ({download.get('size', '?')} bytes) from Slack...")
+            logger.info(
+                f"Downloading {safe_filename} ({download.get('size', '?')} bytes) from Slack..."
+            )
             with httpx.Client(timeout=httpx.Timeout(300.0)) as client:
                 with client.stream(
                     "GET",


### PR DESCRIPTION
In local docker-compose (server_simple.py), images and file attachments from Slack were silently dropped before reaching the agent:
- Images: Extracted but never passed through message queue to agent.execute()
- Files: Metadata received, but never downloaded or made available to agent

Changes:
1. Pass images through message queue to agent_background_task(), which now passes them to session.execute(prompt, images=images)
2. Add _download_file_attachments() to download non-image files in-process to ./attachments/{filename}, matching what the enriched prompt tells agent
3. Fix proxy endpoint from POST to GET (/proxy/files/{token}) to match production server.py implementation

Testing: Local docker-compose with image/file drops should now work.

## Description

<!-- Provide a clear description of what this PR does -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring / code cleanup
- [ ] 🧪 Test improvements
- [ ] 🚀 Performance improvement
- [ ] 🔒 Security fix

## Related Issues

<!-- Link related issues using 'Closes #123' or 'Relates to #456' -->

Closes #

## Changes Made

<!-- Provide a detailed list of changes -->

-
-
-

## Testing

<!-- Describe how you tested these changes -->

### Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Tested locally with Docker Compose
- [ ] Tested in Kubernetes environment (if applicable)

### Testing Steps

1.
2.
3.

## Screenshots / Videos

<!-- If applicable, add screenshots or videos showing the changes -->

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] Code follows the project's style guidelines (`black` and `ruff` for Python)
- [ ] Self-review of code completed
- [ ] Comments added for complex logic
- [ ] Documentation updated (README, docs/, etc.)
- [ ] No new warnings introduced
- [ ] Tests added/updated and passing
- [ ] All CI checks passing
- [ ] Branch is up to date with `main`

## Additional Context

<!-- Any other information that reviewers should know -->

## Deployment Notes

<!-- Any special considerations for deploying this change? -->

- [ ] Requires database migration
- [ ] Requires configuration changes
- [ ] Requires environment variable updates
- [ ] Requires new secrets/credentials
- [ ] Backward compatible
- [ ] None of the above
