### PR TITLE
fix: Prefer in-cluster auth over kubeconfig in remediation scripts

### DIFF
--- a/sre-agent/.claude/skills/remediation/scripts/restart_pod.py
+++ b/sre-agent/.claude/skills/remediation/scripts/restart_pod.py
@@ -22,16 +22,25 @@ from kubernetes.client.rest import ApiException
 
 
 def get_k8s_client():
-    """Get Kubernetes API client."""
-    kubeconfig = Path.home() / ".kube" / "config"
-    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    """Get Kubernetes API client.
 
-    if kubeconfig.exists():
-        k8s_config.load_kube_config()
-    elif in_cluster.exists():
+    Prefers in-cluster service account auth (correct RBAC identity)
+    over kubeconfig (which may resolve to the EC2 node IAM identity).
+    """
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
         k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
     else:
-        print("Error: Kubernetes not configured.", file=sys.stderr)
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     return client.CoreV1Api()

--- a/sre-agent/.claude/skills/remediation/scripts/rollback_deployment.py
+++ b/sre-agent/.claude/skills/remediation/scripts/rollback_deployment.py
@@ -25,16 +25,25 @@ from kubernetes.client.rest import ApiException
 
 
 def get_k8s_clients():
-    """Get Kubernetes API clients."""
-    kubeconfig = Path.home() / ".kube" / "config"
-    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    """Get Kubernetes API clients.
 
-    if kubeconfig.exists():
-        k8s_config.load_kube_config()
-    elif in_cluster.exists():
+    Prefers in-cluster service account auth (correct RBAC identity)
+    over kubeconfig (which may resolve to the EC2 node IAM identity).
+    """
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
         k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
     else:
-        print("Error: Kubernetes not configured.", file=sys.stderr)
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     return client.AppsV1Api()

--- a/sre-agent/.claude/skills/remediation/scripts/scale_deployment.py
+++ b/sre-agent/.claude/skills/remediation/scripts/scale_deployment.py
@@ -22,16 +22,25 @@ from kubernetes.client.rest import ApiException
 
 
 def get_k8s_client():
-    """Get Kubernetes API client."""
-    kubeconfig = Path.home() / ".kube" / "config"
-    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    """Get Kubernetes API client.
 
-    if kubeconfig.exists():
-        k8s_config.load_kube_config()
-    elif in_cluster.exists():
+    Prefers in-cluster service account auth (correct RBAC identity)
+    over kubeconfig (which may resolve to the EC2 node IAM identity).
+    """
+    in_cluster = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    kubeconfig = Path.home() / ".kube" / "config"
+
+    if in_cluster.exists():
         k8s_config.load_incluster_config()
+        print("[k8s-auth] Using in-cluster service account", file=sys.stderr)
+    elif kubeconfig.exists():
+        k8s_config.load_kube_config()
+        print("[k8s-auth] Using kubeconfig (fallback)", file=sys.stderr)
     else:
-        print("Error: Kubernetes not configured.", file=sys.stderr)
+        print(
+            "Error: Kubernetes not configured. No in-cluster token or ~/.kube/config.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     return client.AppsV1Api()


### PR DESCRIPTION
## Summary

- Remediation scripts (restart_pod, rollback_deployment, scale_deployment) checked kubeconfig before in-cluster SA token, causing RBAC failures in sandbox pods
- Fixed to match the pattern already on main for infrastructure-kubernetes scripts: in-cluster first, docstring, `[k8s-auth]` stderr logging

## Context

Supersedes #382 — the other 7/10 changes from that PR are already on main. These 3 remediation scripts were the only files where the fix was still missing.

## Test plan

- [ ] Verify remediation skills work in warm pool sandbox (in-cluster SA auth)
- [ ] Verify scripts still work locally with kubeconfig fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)