### PR TITLE
infra: Enable AI pipeline on staging + wire URLs

### DIFF
--- a/charts/incidentfox/templates/ai-pipeline-api.yaml
+++ b/charts/incidentfox/templates/ai-pipeline-api.yaml
@@ -47,6 +47,10 @@ spec:
               value: {{ default "pilot" .Values.global.configService.orgId | quote }}
             - name: PIPELINE_API_PORT
               value: {{ .Values.services.aiPipelineApi.servicePort | quote }}
+            {{- if .Values.services.ultimateRag.enabled }}
+            - name: RAPTOR_URL
+              value: {{ printf "http://incidentfox-ultimate-rag.%s.svc.cluster.local:%d" .Values.namespace (.Values.services.ultimateRag.servicePort | int) | quote }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /health

--- a/charts/incidentfox/templates/slack-bot.yaml
+++ b/charts/incidentfox/templates/slack-bot.yaml
@@ -115,6 +115,11 @@ spec:
             - name: WEB_UI_URL
               value: {{ .Values.global.webUiUrl | quote }}
             {{- end }}
+            {{- if .Values.services.aiPipelineApi.enabled }}
+            # AI Pipeline API URL for onboarding scans
+            - name: AI_PIPELINE_API_URL
+              value: {{ printf "http://incidentfox-ai-pipeline-api.%s.svc.cluster.local:%d" .Values.namespace (.Values.services.aiPipelineApi.servicePort | int) | quote }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /health

--- a/charts/incidentfox/values.staging.yaml
+++ b/charts/incidentfox/values.staging.yaml
@@ -338,7 +338,10 @@ services:
       secretKey: ANTHROPIC_API_KEY
 
   aiPipelineApi:
-    enabled: false  # Deprecated - use ultimateRag instead
+    enabled: true
+    image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-ai-pipeline:latest"
+    replicas: 1
+    servicePort: 8085
 
   knowledgeBase:
     enabled: false  # Deprecated - use ultimateRag instead

--- a/slack-bot/config_client.py
+++ b/slack-bot/config_client.py
@@ -1202,7 +1202,7 @@ class ConfigServiceClient:
         """
         pipeline_url = os.environ.get(
             "AI_PIPELINE_API_URL",
-            "http://ai-pipeline-api-svc.incidentfox-prod.svc.cluster.local:8085",
+            "http://incidentfox-ai-pipeline-api:8085",
         )
 
         # Fetch team's routed channels for team-scoped scanning


### PR DESCRIPTION
## Summary
- Enable `aiPipelineApi` on staging (was disabled, blocking the entire onboarding scan pipeline)
- Add `RAPTOR_URL` to the AI pipeline template (connects to ultimate-rag for RAG ingestion)
- Add `AI_PIPELINE_API_URL` to the slack-bot template (so scan trigger reaches the right service)
- Fix hardcoded fallback URL in `config_client.py` (was pointing to `incidentfox-prod` namespace with wrong service name)

## Test plan
- [ ] Deploy to staging (ai-pipeline + slack-bot)
- [ ] Join a team via the setup modal
- [ ] Verify ai-pipeline pod starts and is healthy
- [ ] Verify onboarding scan triggers successfully (no DNS errors)
- [ ] Verify RAG knowledge is created in team-scoped tree
- [ ] Verify integration recommendations are generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)