### PR TITLE
fix: Add fastapi/uvicorn to AI pipeline requirements

### DIFF
--- a/ai_pipeline/requirements.txt
+++ b/ai_pipeline/requirements.txt
@@ -18,3 +18,7 @@ pydantic>=2.0.0
 
 # Async support
 anyio>=4.0.0
+
+# API server
+fastapi>=0.115.0
+uvicorn>=0.32.0


### PR DESCRIPTION
## Summary
- Add `fastapi>=0.115.0` and `uvicorn>=0.32.0` to `ai_pipeline/requirements.txt`
- These are needed by `api_server.py` but were missing, causing `ModuleNotFoundError` on pod startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)