### PR TITLE
docs: Fix Slack bot setup for new users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,20 @@
 #   make dev        Start all services (postgres, config-service, credential-proxy, sre-agent, slack-bot)
 #                   Note: slack-bot requires SLACK_BOT_TOKEN + SLACK_APP_TOKEN in .env
 #   make stop       Stop all services
+#   make restart    Restart all services (rebuild)
 #   make logs       Follow all logs
 #   make clean      Remove containers, volumes, and images
 #   make db-shell   Open psql shell
 
-.PHONY: dev stop logs logs-agent logs-config status clean db-shell
+.PHONY: dev dev-slack restart stop logs logs-agent logs-config status clean db-shell
 
 dev:
+	docker compose up -d --build
+
+# Backward-compat alias (dev-slack was removed — slack-bot now starts with `make dev`)
+dev-slack: dev
+
+restart:
 	docker compose up -d --build
 
 stop:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Then edit `.env` to add your `ANTHROPIC_API_KEY` (or any other LLM provider — 
 
 That's it. IncidentFox starts Postgres, config-service, sre-agent, and the web console. Migrations run automatically.
 
-**Want to test via Slack?** [Create a Slack app](https://api.slack.com/apps?new_app=1) using the [manifest](slack-bot/slack-manifest.json), add `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` to `.env`, and run `make dev-slack`. [Full Slack setup guide](docs/SLACK_SETUP.md).
+**Want to test via Slack?** [Create a Slack app](https://api.slack.com/apps?new_app=1) using the [manifest](slack-bot/slack-manifest.json), add `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` to `.env`, and restart with `make dev`. [Full Slack setup guide](docs/SLACK_SETUP.md).
 
 ## Open-source vs. paid
 

--- a/docs/SLACK_SETUP.md
+++ b/docs/SLACK_SETUP.md
@@ -19,82 +19,7 @@ Connect IncidentFox to your Slack workspace. Takes about 5 minutes.
 
    <img width="550" alt="Select workspace" src="https://github.com/user-attachments/assets/0eb2ee77-deb8-4959-841b-8e7d0ede91b2" />
 
-3. **Paste the app manifest** below:
-
-```json
-{
-    "display_information": {
-        "name": "IncidentFox(Local)",
-        "description": "AI SRE copilot",
-        "background_color": "#c96b28",
-        "long_description": "IncidentFox — Your AI On-Call & Incident Response Agent in Slack\r\n\r\nIncidentFox is an AI-powered SRE and DevOps agent that lives in Slack.\r\n\r\nPing the IncidentFox bot to investigate alerts, diagnose incidents, and guide responders through resolution — without leaving your channel.\r\n\r\nReduce MTTR, cut through alert noise, and give your on-call engineers an always-available teammate.\r\n\r\n---\r\n\r\n🔔 Turn alerts into action\r\n\r\nIncidentFox connects your monitoring and infrastructure tools to Slack and helps you understand what's happening — fast.\r\n\r\n*Use IncidentFox to:*\r\n- Explain alerts in plain English\r\n- Investigate metrics, logs, and recent changes\r\n- Correlate signals across systems\r\n- Identify likely root causes\r\n- Suggest next steps during active incidents\r\n\r\nNo more copy-pasting dashboards. No more guessing.\r\n\r\n---\r\n\r\n🤖 An AI ops agent for real incidents\r\n\r\nIncidentFox isn't a generic chatbot. It's built specifically for incident management, on-call response, and production operations.\r\n\r\n*It understands:*\r\n- Alert context and history\r\n- System behavior over time\r\n- Dependencies across services\r\n- What usually breaks — and how teams fix it\r\n\r\nAsk operational questions during incidents or after, and get answers grounded in your environment.\r\n\r\n---\r\n\r\n🔌 Works with your existing monitoring stack\r\n\r\nIncidentFox integrates with popular DevOps and SRE tools, including:\r\n- Prometheus & VictoriaMetrics\r\n- Grafana\r\n- Elasticsearch\r\n- Major cloud platforms\r\n- Kubernetes\r\n- Temporal\r\n- And a lot more\r\n\r\nBring signals together in one place — Slack.\r\n\r\n---\r\n\r\n💬 Slack-first incident response\r\n\r\nIncidentFox is designed for how teams actually respond to incidents:\r\n- Trigger investigations from alerts\r\n- Ask questions in channels or DMs\r\n- Get step-by-step guidance during incidents\r\n- Share findings instantly with your team\r\n\r\nEverything happens where your team already collaborates.\r\n\r\n---\r\n\r\n🔐 Secure, transparent, and configurable\r\n\r\nIncidentFox only investigates when triggered by a user or an alert.\r\n\r\n*You control:*\r\n- Which data sources are connected\r\n- What the bot can access\r\n- How information is shared in Slack\r\n\r\nNo passive monitoring. No hidden behavior.\r\n\r\n---\r\n\r\n👥 Built for\r\n\r\n- SRE & DevOps teams\r\n- On-call engineers\r\n- Incident commanders\r\n- Platform & infrastructure teams\r\n\r\nIf Slack is your incident command center, IncidentFox fits right in."
-    },
-    "features": {
-        "app_home": {
-            "home_tab_enabled": true,
-            "messages_tab_enabled": false,
-            "messages_tab_read_only_enabled": false
-        },
-        "bot_user": {
-            "display_name": "IncidentFox(Demo)",
-            "always_online": true
-        },
-        "unfurl_domains": [
-            "player.vimeo.com"
-        ]
-    },
-    "oauth_config": {
-        "redirect_urls": [
-            "https://slack-staging.incidentfox.ai/slack/oauth_redirect"
-        ],
-        "scopes": {
-            "bot": [
-                "app_mentions:read",
-                "channels:history",
-                "channels:join",
-                "channels:read",
-                "chat:write",
-                "chat:write.customize",
-                "files:read",
-                "files:write",
-                "groups:history",
-                "groups:read",
-                "im:history",
-                "im:read",
-                "im:write",
-                "links:read",
-                "links:write",
-                "metadata.message:read",
-                "mpim:history",
-                "mpim:read",
-                "reactions:read",
-                "reactions:write",
-                "usergroups:read",
-                "users:read",
-                "users:read.email",
-                "links.embed:write"
-            ]
-        }
-    },
-    "settings": {
-        "event_subscriptions": {
-            "bot_events": [
-                "app_home_opened",
-                "app_mention",
-                "link_shared",
-                "message.channels"
-            ]
-        },
-        "interactivity": {
-            "is_enabled": true,
-            "request_url": "https://slack-staging.incidentfox.ai/slack/events"
-        },
-        "org_deploy_enabled": false,
-        "socket_mode_enabled": true,
-        "token_rotation_enabled": false
-    }
-}
-```
+3. **Paste the app manifest** from [`slack-bot/slack-manifest.json`](../slack-bot/slack-manifest.json) (copy the entire file contents)
 
    <img width="532" alt="Paste manifest" src="https://github.com/user-attachments/assets/2b926f88-9f2d-4f66-bb50-cc539b888353" />
 
@@ -122,20 +47,26 @@ Go to **Basic Information → App-Level Tokens** → **Generate Token and Scopes
 
 ## 3. Configure and Start
 
-Add your tokens to `.env`:
+If you haven't already, copy the example environment file:
 
 ```bash
-SLACK_BOT_TOKEN=xoxb-your-bot-token
-SLACK_APP_TOKEN=xapp-your-app-token
-ANTHROPIC_API_KEY=sk-ant-your-api-key
+cp .env.example .env
 ```
+
+Then edit `.env` to fill in your tokens:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-your-api-key          # or whichever LLM provider you use
+SLACK_BOT_TOKEN=xoxb-your-bot-token            # from step 2
+SLACK_APP_TOKEN=xapp-your-app-token            # from step 2
+```
+
+> **Important:** Make sure `CONFIG_MODE=local` is in your `.env` (it's included by default when you copy from `.env.example`). This is required for local Slack routing to work.
 
 Start (or restart) the stack:
 
 ```bash
-make dev       # first time
-# or
-make restart   # if already running
+make dev       # starts all services (or rebuilds if already running)
 ```
 
 That's it. The slack-bot auto-connects via Socket Mode and registers your workspace — no additional configuration needed.
@@ -179,6 +110,29 @@ Common causes:
 ### `invalid_auth` on App Token
 
 `SLACK_APP_TOKEN` is missing the `connections:write` scope, or is invalid. Regenerate from **Basic Information → App-Level Tokens**.
+
+### `No routing for channel` warning
+
+The bot receives messages but doesn't respond. Logs show:
+```
+[WARNING] No routing for channel=C..., workspace=T...
+```
+
+This means the bot can't determine which team should handle the message. Fix:
+
+1. Make sure `CONFIG_MODE=local` is in your `.env`:
+   ```bash
+   docker compose exec slack-bot env | grep CONFIG_MODE
+   # Should print: CONFIG_MODE=local
+   ```
+   If missing, add `CONFIG_MODE=local` to `.env` and restart with `make dev`.
+
+2. Check that routing registered at startup:
+   ```bash
+   docker compose logs slack-bot | grep -i "routing"
+   # Should show: "Registered local routing for workspace T..."
+   ```
+   If you see `"Could not auto-register local routing"`, config-service may not have been ready. Restart just the slack-bot: `docker compose restart slack-bot`.
 
 ### Bot exits on startup
 


### PR DESCRIPTION
## Summary

New users following the README to set up Slack would encounter the `"No routing for channel"` error because `CONFIG_MODE=local` was required but not documented. This PR fixes the documentation and adds backward-compatible Makefile targets to support both old and new workflows.

## Changes Made

- **README.md**: Replace deprecated `make dev-slack` (removed in PR #419) with `make dev`
- **Makefile**: Add `dev-slack` backward-compat alias and `restart` target so old instructions don't break
- **SLACK_SETUP.md Step 1**: Replace stale inline manifest with link to `slack-bot/slack-manifest.json` (single source of truth; the inline copy was missing `commands` scope and `/setup-team` command)
- **SLACK_SETUP.md Step 3**: Change from "create minimal 3-line .env" to "start with `cp .env.example .env`" to ensure `CONFIG_MODE=local` is present (this is what the README recommends but wasn't clear in SLACK_SETUP.md)
- **SLACK_SETUP.md Step 3**: Add prominent callout warning that `CONFIG_MODE=local` is required for local Slack routing
- **SLACK_SETUP.md Troubleshooting**: Add new section for `"No routing for channel"` warning with diagnostic steps

## Testing

Followed the README as a new user would: `cp .env.example .env` → `make dev` → created Slack app using manifest → added tokens to `.env` → verified routing auto-registers.

## Backward Compatibility

✅ Users with old instructions (`make dev-slack`, `make restart`) will not break — these are now aliases that work.

🔧 No code changes — documentation and Makefile targets only.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>