### PR TITLE
fix: Workspace routing + migration init container for prod 403

### DIFF
--- a/charts/incidentfox/templates/config-service.yaml
+++ b/charts/incidentfox/templates/config-service.yaml
@@ -24,6 +24,32 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 1000
+      {{- if not (eq (toString (default true .Values.services.configService.migrations.enabled)) "false") }}
+      initContainers:
+        - name: run-migrations
+          image: {{ required "services.configService.image is required" .Values.services.configService.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          command: ["alembic", "upgrade", "head"]
+          workingDir: /app
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.database.databaseUrlSecretName }}
+                  key: {{ .Values.global.database.databaseUrlSecretKey }}
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      {{- end }}
       containers:
         - name: config-service
           image: {{ required "services.configService.image is required" .Values.services.configService.image }}

--- a/slack-bot/config_client.py
+++ b/slack-bot/config_client.py
@@ -124,6 +124,16 @@ class ConfigServiceClient:
             )
             logger.info(f"Created team node: {team_response}")
 
+            # Step 2.5: Set workspace routing so lookup can resolve this org
+            self._update_config(
+                org_id,
+                team_node_id,
+                {"routing": {"slack_workspace_ids": [slack_team_id]}},
+            )
+            logger.info(
+                f"Set workspace routing for {org_id}: slack_workspace_ids=[{slack_team_id}]"
+            )
+
             # Step 3: Issue team token
             token_response = self._issue_team_token(
                 org_id=org_id,

--- a/slack-bot/modal_handler.py
+++ b/slack-bot/modal_handler.py
@@ -903,7 +903,5 @@ def handle_github_app_install_button(ack, body):
     """
     ack()
     logger.info(
-        "GitHub App install button clicked",
-        user_id=body.get("user", {}).get("id"),
-        team_id=body.get("team", {}).get("id"),
+        f"GitHub App install button clicked: user_id={body.get('user', {}).get('id')}, team_id={body.get('team', {}).get('id')}"
     )


### PR DESCRIPTION
## Summary
- **Root cause**: `provision_workspace()` never set `routing.slack_workspace_ids`, so routing lookup failed for all newly installed workspaces → tenant defaulted to `local` → credential-resolver denied with 403
- Adds routing setup as Step 2.5 in `provision_workspace()` (follows same pattern as `register_local_routing()`)
- Fixes `Logger._log() TypeError` in GitHub App install button handler (invalid kwargs → f-string)
- Adds Alembic migration init container to config-service Helm template (fixes missing `scheduled_jobs` table in prod)

## Test plan
- [ ] Deploy to prod (all services except ultimate-rag)
- [ ] Backfill routing for existing broken workspaces via config-service admin API
- [ ] Install bot in a new test workspace → verify routing resolves correctly
- [ ] Verify config-service init container runs migrations successfully
- [ ] Check GitHub App install button no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)