### PR TITLE
fix(helm): nil-safe nested values for config-service migrations

### DIFF
--- a/charts/incidentfox/templates/config-service.yaml
+++ b/charts/incidentfox/templates/config-service.yaml
@@ -24,7 +24,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 1000
-      {{- if not (eq (toString (default true .Values.services.configService.migrations.enabled)) "false") }}
+      {{- if not (eq (toString (dig "migrations" "enabled" true .Values.services.configService)) "false") }}
       initContainers:
         - name: run-migrations
           image: {{ required "services.configService.image is required" .Values.services.configService.image }}


### PR DESCRIPTION
Follow-up to #456. Fixes Helm template nil pointer when migrations key doesn't exist in values.