### PR TITLE
fix: Add missing SLACK_BASE_URL env var to sandbox configuration

### DIFF
--- a/sre-agent/sandbox_manager.py
+++ b/sre-agent/sandbox_manager.py
@@ -622,6 +622,10 @@ static_resources:
                                         "name": "AMPLITUDE_BASE_URL",
                                         "value": f"http://credential-resolver-svc.{cred_resolver_ns}.svc.cluster.local:8002/amplitude",
                                     },
+                                    {
+                                        "name": "SLACK_BASE_URL",
+                                        "value": f"http://credential-resolver-svc.{cred_resolver_ns}.svc.cluster.local:8002/slack",
+                                    },
                                     # Credential resolver URL for SDK-based integrations (AWS, Azure, GCP)
                                     # Scripts call /api/credentials/{id} to fetch creds at runtime
                                     {


### PR DESCRIPTION
## Summary
- Adds missing `SLACK_BASE_URL` environment variable to sandbox pod configuration in `sandbox_manager.py`
- Routes Slack API calls through the credential-resolver proxy, matching the pattern used by all other integrations

## Problem
The Slack integration was failing with "Can't connect to Slack authentication backend" because `SLACK_BASE_URL` was not set during sandbox creation. This caused `slack_client.py` to fall back to direct Slack API access, which doesn't work in the credential-resolver proxy architecture since `SLACK_BOT_TOKEN` is injected by the proxy.

## Solution
Added `SLACK_BASE_URL` configuration following the same pattern as other integrated services (Datadog, Grafana, GitHub, Amplitude). The variable routes Slack API calls through:
```
http://credential-resolver-svc.{namespace}.svc.cluster.local:8002/slack
```

## Test plan
- [ ] Verify sandbox creation includes `SLACK_BASE_URL` env var
- [ ] Test Slack search functionality after deployment
- [ ] Confirm Slack skill scripts can connect to credential-resolver proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)