### PR TITLE
fix: skip @mention handler when auto-investigate fires for same message

### DIFF
--- a/slack-bot/investigation_handler.py
+++ b/slack-bot/investigation_handler.py
@@ -558,6 +558,22 @@ def handle_mention(event, say, client, context):
     logger.info(
         f"🔔 APP_MENTION EVENT RECEIVED: channel={event.get('channel')}, user={event.get('user')}, ts={event.get('ts')}"
     )
+
+    # Skip if this is a top-level message in an auto-investigate channel —
+    # the message handler already triggered auto-investigate for it.
+    if not event.get("thread_ts"):
+        channel_id = event.get("channel")
+        slack_team_id = context.get("team_id")
+        if (
+            channel_id
+            and slack_team_id
+            and _is_auto_investigate_channel(slack_team_id, channel_id)
+        ):
+            logger.info(
+                f"⏭️  Skipping app_mention — auto-investigate already handling top-level message in {channel_id}"
+            )
+            return
+
     thread = threading.Thread(
         target=_handle_mention_impl,
         args=(event, say, client, context),


### PR DESCRIPTION
## Summary
- In auto-investigate channels, both `message` event (auto-investigate) and `app_mention` event fire for the same @mention message
- The second handler gets "Session already executing" or a 403, showing the user an error
- Fix: skip `app_mention` for top-level messages in auto-investigate channels since auto-investigate already handles them

## Root cause
Slack fires two events for `@IncidentFox <message>`:
1. `message` event → auto-investigate handler fires (correct)
2. `app_mention` event → @mention handler fires (duplicate, causes conflict)

## Test plan
- [ ] @mention bot in auto-investigate channel → single investigation, no error
- [ ] @mention bot in regular channel → works as before
- [ ] Reply to thread in auto-investigate channel → works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)