### PR TITLE
fix: auto-investigate only responding to @mentions

### DIFF
--- a/docs/SLACK_SETUP.md
+++ b/docs/SLACK_SETUP.md
@@ -82,7 +82,8 @@ Connect IncidentFox to your Slack workspace. Takes about 5 minutes.
                 "app_home_opened",
                 "app_mention",
                 "link_shared",
-                "message.channels"
+                "message.channels",
+                "message.groups"
             ]
         },
         "interactivity": {

--- a/orchestrator/docs/WEBHOOKS.md
+++ b/orchestrator/docs/WEBHOOKS.md
@@ -341,7 +341,7 @@ curl -X PUT "http://config-service:8080/api/v1/config/me" \
 1. Go to https://api.slack.com/apps
 2. Select your app → Event Subscriptions
 3. Set Request URL: `https://on3vboii0g.execute-api.us-west-2.amazonaws.com/webhooks/slack/events`
-4. Subscribe to events: `app_mention`, `message.channels`
+4. Subscribe to events: `app_mention`, `message.channels`, `message.groups`
 
 ### GitHub App
 

--- a/slack-bot/README.md
+++ b/slack-bot/README.md
@@ -43,6 +43,7 @@ python app.py
 7. Subscribe to events (Event Subscriptions → Subscribe to bot events):
    - `app_mention`
    - `message.channels`
+   - `message.groups`
 
 ## Socket Mode vs HTTP Mode
 
@@ -154,7 +155,7 @@ After deployment, configure your Slack app:
 4. **Enable Event Subscriptions**:
    - Toggle ON
    - Request URL: `http://<LOADBALANCER_URL>/slack/events`
-   - Subscribe to bot events: `app_mention`, `message.channels`
+   - Subscribe to bot events: `app_mention`, `message.channels`, `message.groups`
 5. **OAuth & Permissions**: Ensure bot scopes are configured:
    - `app_mentions:read`
    - `chat:write`

--- a/slack-bot/investigation_handler.py
+++ b/slack-bot/investigation_handler.py
@@ -70,24 +70,26 @@ def get_onboarding_modules():
 # ---------------------------------------------------------------------------
 # Auto-investigate channel cache
 # ---------------------------------------------------------------------------
-# Cache: slack_team_id -> set of channel_ids that have auto-investigate enabled.
-# On cache hit (< 5 min old) the check is a pure dict+set lookup — zero latency.
-_auto_investigate_cache: Dict[str, set] = {}
-_auto_investigate_cache_ts: Dict[str, float] = {}
+# Cache: (slack_team_id, channel_id) -> bool indicating auto-investigate enabled.
+# Keyed per-channel so different teams in the same workspace don't poison each
+# other's cache entries.
+_auto_investigate_cache: Dict[tuple, bool] = {}
+_auto_investigate_cache_ts: Dict[tuple, float] = {}
 _AUTO_INVESTIGATE_CACHE_TTL = 300  # 5 minutes
 
 
 def _is_auto_investigate_channel(slack_team_id: str, channel_id: str) -> bool:
     """Check if a channel has auto-investigate enabled. Cached for 5 minutes."""
     now = time.time()
+    cache_key = (slack_team_id, channel_id)
     if (
-        slack_team_id in _auto_investigate_cache
-        and now - _auto_investigate_cache_ts.get(slack_team_id, 0)
+        cache_key in _auto_investigate_cache
+        and now - _auto_investigate_cache_ts.get(cache_key, 0)
         < _AUTO_INVESTIGATE_CACHE_TTL
     ):
-        return channel_id in _auto_investigate_cache[slack_team_id]
+        return _auto_investigate_cache[cache_key]
 
-    # Cache miss — fetch config via routing lookup
+    # Cache miss — fetch config via routing lookup for this specific channel
     try:
         cc = get_config_client()
         routing = cc.lookup_routing(channel_id, workspace_id=slack_team_id)
@@ -98,9 +100,10 @@ def _is_auto_investigate_channel(slack_team_id: str, channel_id: str) -> bool:
         else:
             config = {}
         auto_channels = set(config.get("auto_investigate", {}).get("channel_ids", []))
-        _auto_investigate_cache[slack_team_id] = auto_channels
-        _auto_investigate_cache_ts[slack_team_id] = now
-        return channel_id in auto_channels
+        result = channel_id in auto_channels
+        _auto_investigate_cache[cache_key] = result
+        _auto_investigate_cache_ts[cache_key] = now
+        return result
     except Exception as e:
         logger.warning(f"Failed to check auto_investigate config: {e}")
         return False

--- a/slack-bot/slack-manifest.json
+++ b/slack-bot/slack-manifest.json
@@ -67,7 +67,8 @@
                 "app_home_opened",
                 "app_mention",
                 "link_shared",
-                "message.channels"
+                "message.channels",
+                "message.groups"
             ]
         },
         "interactivity": {

--- a/slack-bot/slack-manifest.staging.json
+++ b/slack-bot/slack-manifest.staging.json
@@ -65,6 +65,7 @@
                 "app_mention",
                 "member_joined_channel",
                 "message.channels",
+                "message.groups",
                 "message.im"
             ]
         },


### PR DESCRIPTION
## Summary
- **Cache poisoning fix**: `_is_auto_investigate_channel` cached per workspace but filled per team — messages from other teams' channels overwrote the cache with empty auto-investigate config. Now keyed per `(workspace, channel)` tuple.
- **Missing `message.groups` event**: Slack manifests subscribed to `message.channels` (public) but not `message.groups` (private). If the auto-investigate channel is private, the bot never received message events — only `app_mention` worked.

## Test plan
- [ ] Deploy to staging and verify auto-investigate fires for regular messages in configured channel
- [ ] Verify @mentions still work (both in auto-investigate channels and normal channels)
- [ ] If channel is private, confirm `message.groups` is added in Slack app dashboard Event Subscriptions
- [ ] Verify cache doesn't get poisoned when messages arrive from other channels first

🤖 Generated with [Claude Code](https://claude.com/claude-code)