### PR TITLE
fix: k8s-gateway env var missing K8S_GATEWAY_ prefix

### DIFF
--- a/charts/incidentfox/templates/k8s-gateway.yaml
+++ b/charts/incidentfox/templates/k8s-gateway.yaml
@@ -60,8 +60,8 @@ spec:
               value: {{ .Values.services.k8sGateway.heartbeatIntervalSeconds | quote }}
             - name: COMMAND_TIMEOUT_SECONDS
               value: {{ .Values.services.k8sGateway.commandTimeoutSeconds | quote }}
-            # Config service URL for token validation
-            - name: CONFIG_SERVICE_URL
+            # Config service URL for token validation (K8S_GATEWAY_ prefix required by pydantic-settings)
+            - name: K8S_GATEWAY_CONFIG_SERVICE_URL
               value: {{ printf "http://incidentfox-config-service.%s.svc.cluster.local:%d" .Values.namespace (int .Values.services.configService.servicePort) | quote }}
           {{- if .Values.services.k8sGateway.livenessProbe.enabled }}
           livenessProbe:


### PR DESCRIPTION
## Summary
- k8s-gateway uses pydantic-settings with `env_prefix="K8S_GATEWAY_"`, so `config_service_url` reads from `K8S_GATEWAY_CONFIG_SERVICE_URL`
- Helm chart was setting `CONFIG_SERVICE_URL` (no prefix), so the gateway fell back to the default `http://config-service:8080` which doesn't resolve
- This caused `[Errno -2] Name or service not known` on every agent token validation, blocking all k8s-agent connections

## Test plan
- [ ] Deploy to production → k8s-gateway pod restarts with correct env var
- [ ] k8s-agent on staging connects successfully to gateway (401 → 200 SSE stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)