### PR TITLE
fix: replace deleted bitnami/kubectl image with official kubectl

### DIFF
--- a/charts/incidentfox/templates/sandbox-warmpool-autoscaler.yaml
+++ b/charts/incidentfox/templates/sandbox-warmpool-autoscaler.yaml
@@ -75,7 +75,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: autoscaler
-              image: {{ .Values.services.sandboxCleanup.image | default "bitnami/kubectl:latest" }}
+              image: {{ .Values.services.sandboxCleanup.image | default "registry.k8s.io/kubectl:v1.31.0" }}
               resources:
                 requests:
                   cpu: "10m"

--- a/charts/incidentfox/values.prod.yaml
+++ b/charts/incidentfox/values.prod.yaml
@@ -287,7 +287,7 @@ services:
   # Sandbox Cleanup for expired sandbox garbage collection
   sandboxCleanup:
     enabled: true
-    image: "bitnami/kubectl:1.29.2"
+    image: "registry.k8s.io/kubectl:v1.31.0"
     schedule: "*/15 * * * *"
 
   # Credential Resolver for sandbox credential injection

--- a/charts/incidentfox/values.staging.yaml
+++ b/charts/incidentfox/values.staging.yaml
@@ -315,7 +315,7 @@ services:
   # Sandbox Cleanup for expired sandbox garbage collection
   sandboxCleanup:
     enabled: true
-    image: "bitnami/kubectl:1.29.2"
+    image: "registry.k8s.io/kubectl:v1.31.0"
     schedule: "*/15 * * * *"
 
   # Credential Resolver for sandbox credential injection

--- a/charts/incidentfox/values.yaml
+++ b/charts/incidentfox/values.yaml
@@ -704,7 +704,7 @@ services:
   # Runs periodically to garbage collect sandboxes past their TTL.
   sandboxCleanup:
     enabled: false  # Enable when using gVisor sandboxes
-    image: "bitnami/kubectl:1.29.2"
+    image: "registry.k8s.io/kubectl:v1.31.0"
     schedule: "*/15 * * * *"  # Every 15 minutes
     successfulJobsHistoryLimit: 3
     failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary
- `bitnami/kubectl:1.29.2` tag was removed from Docker Hub (Bitnami deletes old versioned tags)
- sandbox-cleanup and warmpool-autoscaler CronJob pods stuck in ImagePullBackOff (18k+ restarts over 13 days on prod)
- Switched to `registry.k8s.io/kubectl:v1.31.0` — official K8s image with stable versioned tags

## Test plan
- [ ] Deploy to production → CronJob pods should pull the new image successfully
- [ ] Verify sandbox-cleanup and warmpool-autoscaler CronJobs complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)