### PR TITLE
fix: use bitnami/kubectl:latest for CronJob scripts

### DIFF
--- a/charts/incidentfox/templates/sandbox-warmpool-autoscaler.yaml
+++ b/charts/incidentfox/templates/sandbox-warmpool-autoscaler.yaml
@@ -75,7 +75,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: autoscaler
-              image: {{ .Values.services.sandboxCleanup.image | default "registry.k8s.io/kubectl:v1.31.0" }}
+              image: {{ .Values.services.sandboxCleanup.image | default "bitnami/kubectl:latest" }}
               resources:
                 requests:
                   cpu: "10m"

--- a/charts/incidentfox/values.prod.yaml
+++ b/charts/incidentfox/values.prod.yaml
@@ -287,7 +287,7 @@ services:
   # Sandbox Cleanup for expired sandbox garbage collection
   sandboxCleanup:
     enabled: true
-    image: "registry.k8s.io/kubectl:v1.31.0"
+    image: "bitnami/kubectl:latest"
     schedule: "*/15 * * * *"
 
   # Credential Resolver for sandbox credential injection

--- a/charts/incidentfox/values.staging.yaml
+++ b/charts/incidentfox/values.staging.yaml
@@ -315,7 +315,7 @@ services:
   # Sandbox Cleanup for expired sandbox garbage collection
   sandboxCleanup:
     enabled: true
-    image: "registry.k8s.io/kubectl:v1.31.0"
+    image: "bitnami/kubectl:latest"
     schedule: "*/15 * * * *"
 
   # Credential Resolver for sandbox credential injection

--- a/charts/incidentfox/values.yaml
+++ b/charts/incidentfox/values.yaml
@@ -704,7 +704,7 @@ services:
   # Runs periodically to garbage collect sandboxes past their TTL.
   sandboxCleanup:
     enabled: false  # Enable when using gVisor sandboxes
-    image: "registry.k8s.io/kubectl:v1.31.0"
+    image: "bitnami/kubectl:latest"
     schedule: "*/15 * * * *"  # Every 15 minutes
     successfulJobsHistoryLimit: 3
     failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary
- Follow-up to #472 — the official `registry.k8s.io/kubectl` image is too minimal (no bash, jq, curl)
- sandbox-cleanup and warmpool-autoscaler scripts need these tools
- Switch to `bitnami/kubectl:latest` which has them

🤖 Generated with [Claude Code](https://claude.com/claude-code)