### PR TITLE
fix: add K8S_GATEWAY_URL to warm pool sandbox template

### DIFF
--- a/charts/incidentfox/templates/sandbox-warmpool.yaml
+++ b/charts/incidentfox/templates/sandbox-warmpool.yaml
@@ -330,6 +330,9 @@ spec:
           value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/amplitude"
         - name: VERCEL_BASE_URL
           value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/vercel"
+        # K8s Gateway: route K8s commands to customer clusters via k8s-agent
+        - name: K8S_GATEWAY_URL
+          value: "http://incidentfox-k8s-gateway.{{ .Values.namespace }}.svc.cluster.local:8085"
         # RAPTOR knowledge base: internal K8s service (no auth needed)
         - name: RAPTOR_URL
           value: "http://incidentfox-rag.{{ .Values.namespace }}.svc.cluster.local:8000"


### PR DESCRIPTION
## Summary

- `K8S_GATEWAY_URL` env var was present in `sandbox_manager.py` (dynamic pods) but **missing from `sandbox-warmpool.yaml`** (warm pool pods)
- Without this env var, the `k8s_gateway_client.py` and `list_clusters.py` scripts have no gateway URL to connect to
- The agent loaded the gateway-first SKILL.md, but the scripts couldn't work, so it fell back to direct `kubectl` which fails (SA token disabled)

This was the actual root cause of the "AWS credentials not configured" error — the agent tried kubectl as a fallback.

## Test plan

- [ ] Deploy → verify warm pool pods have `K8S_GATEWAY_URL` env var set
- [ ] Trigger k8s investigation → agent should run `list_clusters.py` successfully
- [ ] `list_clusters.py` → discovers incidentfox-demo cluster → `list_namespaces.py --cluster-id` via gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)