### PR TITLE
feat: enable Langfuse observability in production

### DIFF
--- a/charts/incidentfox/values.prod.yaml
+++ b/charts/incidentfox/values.prod.yaml
@@ -93,7 +93,12 @@ externalSecrets:
       internalTokenKey: internal_token
       internalTokenRemoteRefKey: incidentfox/prod/orchestrator_internal_token
     langfuse:
-      enabled: false  # Using OpenAI tracing UI instead
+      enabled: true
+      secretName: incidentfox-langfuse
+      publicKeyKey: LANGFUSE_PUBLIC_KEY
+      secretKeyKey: LANGFUSE_SECRET_KEY
+      publicKeyRemoteRefKey: incidentfox/prod/langfuse_public_key
+      secretKeyRemoteRefKey: incidentfox/prod/langfuse_secret_key
     googleChat:
       enabled: true
     teams:
@@ -262,9 +267,14 @@ services:
         value: "http://incidentfox-k8s-gateway.incidentfox-prod.svc.cluster.local:8085"
       - name: SANDBOX_TTL_MINUTES
         value: "20"
-    # Agent observability — disabled in production
+    # Agent observability — Langfuse for production tracing
     agentObservability:
-      backend: "none"
+      backend: "langfuse"
+      langfuse:
+        host: "https://us.cloud.langfuse.com"
+        secretName: "incidentfox-langfuse"
+        publicKeyKey: "LANGFUSE_PUBLIC_KEY"
+        secretKeyKey: "LANGFUSE_SECRET_KEY"
 
   # Sandbox Router for routing to sandbox pods
   sandboxRouter:


### PR DESCRIPTION
## Summary

- Enable Langfuse tracing for agent LLM calls in production (matching staging config)
- AWS Secrets Manager entries (`incidentfox/prod/langfuse_public_key`, `incidentfox/prod/langfuse_secret_key`) already exist
- Enables ExternalSecret sync to create `incidentfox-langfuse` k8s secret
- Sets `agentObservability.backend: "langfuse"` with `us.cloud.langfuse.com` host

## Test plan

- [ ] After deploy, verify ExternalSecret `incidentfox-langfuse` syncs successfully
- [ ] Trigger an investigation — verify traces appear in Langfuse dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)