### PR TITLE
fix: add SLACK_BASE_URL to warm pool sandbox template

### DIFF
--- a/charts/incidentfox/templates/sandbox-warmpool.yaml
+++ b/charts/incidentfox/templates/sandbox-warmpool.yaml
@@ -330,12 +330,29 @@ spec:
           value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/amplitude"
         - name: VERCEL_BASE_URL
           value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/vercel"
+        - name: SLACK_BASE_URL
+          value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/slack"
+        # Credential resolver URL for SDK-based integrations (AWS, Azure, GCP)
+        - name: CREDENTIAL_RESOLVER_URL
+          value: "http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002"
+        # Git URL rewriting: route github.com HTTPS through credential-resolver
+        - name: GIT_CONFIG_COUNT
+          value: "1"
+        - name: GIT_CONFIG_KEY_0
+          value: "url.http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/git/.insteadOf"
+        - name: GIT_CONFIG_VALUE_0
+          value: "https://github.com/"
         # K8s Gateway: route K8s commands to customer clusters via k8s-agent
         - name: K8S_GATEWAY_URL
           value: "http://incidentfox-k8s-gateway.{{ .Values.namespace }}.svc.cluster.local:8085"
         # RAPTOR knowledge base: internal K8s service (no auth needed)
         - name: RAPTOR_URL
           value: "http://incidentfox-rag.{{ .Values.namespace }}.svc.cluster.local:8000"
+        # flagd runtime config (for OTel Demo incident scenarios)
+        - name: FLAGD_NAMESPACE
+          value: "otel-demo"
+        - name: FLAGD_CONFIGMAP
+          value: "flagd-config"
         # Laminar tracing (platform observability)
         - name: LMNR_PROJECT_API_KEY
           valueFrom:


### PR DESCRIPTION
## Summary

- `SLACK_BASE_URL` was missing from the warm pool sandbox template (`sandbox-warmpool.yaml`), causing the `not_authed` error when the agent tries to call Slack APIs
- PR #462 added `SLACK_BASE_URL` to `sandbox_manager.py` (direct pod creation), but warm pool pods — which are what's actually used in production — never got it
- Without `SLACK_BASE_URL`, `slack_client.py` falls back to calling `https://slack.com/api` directly with no auth token
- Same bug pattern as PR #477 which fixed the missing `K8S_GATEWAY_URL` in the warm pool template
- Also adds other env vars that were in `sandbox_manager.py` but missing from the warm pool template: `CREDENTIAL_RESOLVER_URL`, `GIT_CONFIG_*` (git URL rewriting), `FLAGD_*` (feature flags)

## Test plan

- [ ] Deploy to staging and verify warm pool pods have `SLACK_BASE_URL` set
- [ ] Run `@IncidentFox` Slack search command and confirm no `not_authed` error
- [ ] Verify `git clone` works in warm pool sandboxes (GIT_CONFIG_* fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)