### PR TITLE
fix: k8s-gateway single replica for in-memory connection state

### DIFF
--- a/charts/incidentfox/values.prod.yaml
+++ b/charts/incidentfox/values.prod.yaml
@@ -360,7 +360,7 @@ services:
   k8sGateway:
     enabled: true
     image: "103002841599.dkr.ecr.us-west-2.amazonaws.com/incidentfox-k8s-gateway:latest"
-    replicas: 2
+    replicas: 1  # Must be 1 — in-memory connection tracking doesn't work with multiple replicas
     logLevel: "INFO"
     resources:
       requests:


### PR DESCRIPTION
## Summary
- Scale k8s-gateway to 1 replica in production. The gateway tracks agent SSE connections in-memory, so with 2+ replicas, execute requests get load-balanced to a pod that doesn't have the agent connection, returning "Cluster not connected".
- Already applied via `kubectl scale` — this makes it persist across deploys.

## Future work
- Add Redis-backed connection state or inter-pod request forwarding to support multiple replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)