### PR TITLE
fix: add GH_HOST to warm pool sandbox template

### DIFF
--- a/charts/incidentfox/templates/sandbox-warmpool.yaml
+++ b/charts/incidentfox/templates/sandbox-warmpool.yaml
@@ -342,6 +342,9 @@ spec:
           value: "url.http://credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8002/git/.insteadOf"
         - name: GIT_CONFIG_VALUE_0
           value: "https://github.com/"
+        # gh CLI: route HTTPS API calls through credential-resolver
+        - name: GH_HOST
+          value: "credential-resolver-svc.{{ .Values.namespace }}.svc.cluster.local:8443"
         # K8s Gateway: route K8s commands to customer clusters via k8s-agent
         - name: K8S_GATEWAY_URL
           value: "http://incidentfox-k8s-gateway.{{ .Values.namespace }}.svc.cluster.local:8085"


### PR DESCRIPTION
## Summary

Moves gh CLI TLS termination from credential-resolver to the Envoy sidecar already running in every sandbox pod. The previous approach ran two full uvicorn processes (HTTP 8002 + HTTPS 8443) which exceeded the 512Mi memory limit (exit code 139 / CrashLoopBackOff).

**What changed:**
- **Envoy warm pool config**: New `gh_tls_proxy` listener on port 8443 with self-signed TLS cert, forwarding to credential-resolver:8002
- **Envoy direct sandbox config** (sandbox_manager.py): Same TLS listener added
- **TLS cert ConfigMap**: `envoy-gh-tls-cert` mounted in the Envoy container
- **`GH_HOST`**: Changed from `credential-resolver-svc:8443` to `localhost:8443` (local Envoy)
- **credential-resolver**: Reverted to single-process HTTP-only (`exec uvicorn`), removed port 8443 from Helm template/services
- **gitleaks**: Allowlisted the dev TLS cert

**Why this is better:**
- Envoy is purpose-built for TLS termination and adds zero memory overhead
- credential-resolver stays single-process (no OOM, no CrashLoopBackOff)
- Follows existing pattern (Envoy already proxies Anthropic, Coralogix on port 8001)

## Test plan

- [ ] Deploy and verify credential-resolver pod is healthy (single process, no crash)
- [ ] Verify warm pool pods have `GH_HOST=localhost:8443`
- [ ] Test `gh repo list` in sandbox — no "Bad credentials" error
- [ ] Test `git clone` in sandbox — works through GIT_CONFIG rewriting

🤖 Generated with [Claude Code](https://claude.com/claude-code)