### PR TITLE
fix: k8s-agent PYTHONUNBUFFERED and gateway URL default

### DIFF
--- a/k8s_agent/Dockerfile
+++ b/k8s_agent/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 
 # Copy source code and install

--- a/k8s_agent/charts/incidentfox-k8s-agent/templates/deployment.yaml
+++ b/k8s_agent/charts/incidentfox-k8s-agent/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ include "incidentfox-k8s-agent.imageTag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
             - name: INCIDENTFOX_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/k8s_agent/src/k8s_agent/config.py
+++ b/k8s_agent/src/k8s_agent/config.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
     cluster_name: str = ""  # Name to identify this cluster
 
     # Gateway connection (default is IncidentFox SaaS gateway)
-    gateway_url: str = "https://orchestrator.incidentfox.ai/gateway"
+    gateway_url: str = "https://ui.incidentfox.ai/gateway"
 
     # Reconnection settings
     initial_reconnect_delay: float = 1.0


### PR DESCRIPTION
## Summary
- Add `PYTHONUNBUFFERED=1` to Dockerfile and Helm deployment template so agent logs are visible in real-time
- Fix gateway URL default from `orchestrator.incidentfox.ai` to `ui.incidentfox.ai` to match the actual ALB ingress path

## Test plan
- [ ] Build k8s-agent image and verify logs stream without buffering delay
- [ ] Verify agent connects to gateway using the correct default URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)