### PR TITLE
fix: GitHub CLI auth and TLS cert trust for sandbox pods

### DIFF
--- a/charts/incidentfox/templates/sandbox-warmpool.yaml
+++ b/charts/incidentfox/templates/sandbox-warmpool.yaml
@@ -507,6 +507,14 @@ spec:
         # gh CLI: route HTTPS API calls through Envoy TLS listener (localhost)
         - name: GH_HOST
           value: "localhost:8443"
+        # gh CLI: placeholder token — Envoy ext_authz injects the real one
+        # (same pattern as ANTHROPIC_API_KEY placeholder above)
+        - name: GH_ENTERPRISE_TOKEN
+          value: "placeholder-proxy-will-inject-real-token"
+        # Trust the self-signed TLS cert used by the Envoy gh proxy listener.
+        # Safe in sandbox: all external HTTPS is proxied through HTTP.
+        - name: SSL_CERT_FILE
+          value: "/etc/ssl/gh-proxy/credential-resolver.crt"
         # K8s Gateway: route K8s commands to customer clusters via k8s-agent
         - name: K8S_GATEWAY_URL
           value: "http://incidentfox-k8s-gateway.{{ .Values.namespace }}.svc.cluster.local:8085"
@@ -563,6 +571,10 @@ spec:
         # Shared volume for JWT injection (Envoy reads, /claim writes)
         - name: jwt-volume
           mountPath: /tmp
+        # Self-signed TLS cert for gh CLI → Envoy proxy (agent needs to trust it)
+        - name: gh-tls-cert
+          mountPath: /etc/ssl/gh-proxy
+          readOnly: true
         resources:
 {{ toYaml .Values.services.agent.warmPool.agentResources | indent 10 }}
         securityContext:

--- a/sre-agent/credential-proxy/src/credential_resolver/domain_mapping.py
+++ b/sre-agent/credential-proxy/src/credential_resolver/domain_mapping.py
@@ -41,6 +41,9 @@ DOMAIN_TO_INTEGRATION: dict[str, str] = {
     "sentry.io": "sentry",
     # PagerDuty
     "api.pagerduty.com": "pagerduty",
+    # GitHub (gh CLI ext_authz sends x-original-host: github.com)
+    "github.com": "github",
+    "api.github.com": "github",
     # GitLab
     "gitlab.com": "gitlab",
     # New Relic

--- a/sre-agent/credential-proxy/src/credential_resolver/main.py
+++ b/sre-agent/credential-proxy/src/credential_resolver/main.py
@@ -2333,11 +2333,23 @@ async def ext_authz_check(request: Request, path: str = ""):
     """
     logger.info(f"ext_authz check: {request.method} {request.url.path}")
 
+    # Distinguish ext_authz requests (from Envoy, have x-original-host) from
+    # direct requests (agent accidentally hitting the catch-all route).
+    target_host = request.headers.get("x-original-host", "")
+    if not target_host:
+        # Direct request to an unregistered path — not an ext_authz call.
+        # Return a clear error instead of a confusing empty 200.
+        logger.warning(f"Direct request to catch-all: {request.method} /{path}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown endpoint: /{path}. "
+            "If this is a proxy request, use the dedicated /<integration>/... path.",
+        )
+
     # 1. Validate JWT and extract tenant context
     tenant_id, team_id, sandbox_name = await extract_tenant_context(request)
 
     # 2. Determine integration from target host and path
-    target_host = request.headers.get("x-original-host", "")
     request_path = request.url.path
     # Strip ext_authz path_prefix if present (envoy prepends /extauthz to avoid
     # hitting LLM proxy routes, but we need the original path for integration mapping)

--- a/sre-agent/sandbox_manager.py
+++ b/sre-agent/sandbox_manager.py
@@ -732,10 +732,20 @@ static_resources:
                                         "name": "K8S_GATEWAY_URL",
                                         "value": f"http://incidentfox-k8s-gateway.{self.namespace}.svc.cluster.local:8085",
                                     },
-                                    # gh CLI: route HTTPS API calls through credential-resolver
+                                    # gh CLI: route HTTPS API calls through Envoy TLS listener
                                     {
                                         "name": "GH_HOST",
                                         "value": "localhost:8443",
+                                    },
+                                    # gh CLI: placeholder token — ext_authz injects real one
+                                    {
+                                        "name": "GH_ENTERPRISE_TOKEN",
+                                        "value": "placeholder-proxy-will-inject-real-token",
+                                    },
+                                    # Trust the self-signed TLS cert for gh CLI proxy
+                                    {
+                                        "name": "SSL_CERT_FILE",
+                                        "value": "/etc/ssl/gh-proxy/credential-resolver.crt",
                                     },
                                     # RAPTOR knowledge base: internal K8s service (no auth needed)
                                     {
@@ -773,6 +783,13 @@ static_resources:
                                     # exposure via `kubectl get pod -o yaml` or /proc/*/environ.
                                     # The /claim endpoint writes it to /tmp/sandbox-jwt and
                                     # sets os.environ["SANDBOX_JWT"] for skill scripts.
+                                ],
+                                "volumeMounts": [
+                                    {
+                                        "name": "gh-tls-cert",
+                                        "mountPath": "/etc/ssl/gh-proxy",
+                                        "readOnly": True,
+                                    },
                                 ],
                                 "resources": {
                                     "requests": {


### PR DESCRIPTION
## Description

The last 5 PRs (#482-486) set up GitHub CLI via Envoy TLS proxy (`GH_HOST=localhost:8443`), but missed two critical missing pieces that prevented `gh` from working:

1. **Missing `GH_ENTERPRISE_TOKEN`**: `gh` CLI requires authentication and treats `localhost:8443` as a GitHub Enterprise host. Without the token env var, `gh` refuses to make any API calls.
2. **Untrusted TLS cert**: The Envoy sidecar's self-signed cert was mounted in the Envoy container but not the agent container where `gh` runs. Go's TLS verifier couldn't verify the cert.

This PR adds the missing authentication and cert trust setup, plus improves error diagnostics for Slack proxy issues.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- Added `GH_ENTERPRISE_TOKEN=placeholder-proxy-will-inject-real-token` to both warm pool and dynamic sandboxes
- Added `SSL_CERT_FILE=/etc/ssl/gh-proxy/credential-resolver.crt` to trust self-signed cert in agent container
- Mounted `gh-tls-cert` ConfigMap in agent container (previously only in Envoy sidecar)
- Added `github.com` and `api.github.com` to domain mapping for ext_authz integration lookup
- Improved catch-all handler to return clear 404 with error details for direct requests (instead of confusing empty 200)

## Testing

- [x] Code follows ruff lint checks (all checks passed)
- [x] Helm lint passed for sandbox-warmpool.yaml with prod values

### Deployment Notes

- [x] Backward compatible
- [ ] Requires new secrets/credentials (using existing gh-tls-cert ConfigMap from PR #485)

🤖 Generated with [Claude Code](https://claude.com/claude-code)