### PR TITLE
Miminized github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,104 +2,45 @@ name: 🐛 Bug Report
 description: Report a bug or unexpected behavior
 title: "[Bug]: "
 labels: ["bug", "needs-triage"]
-body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to report this bug! Please provide as much detail as possible.
 
+body:
   - type: textarea
     id: description
     attributes:
-      label: Describe the bug
-      description: A clear description of what the bug is
-      placeholder: Tell us what happened
+      label: Description
+      description: Please fill out the template below
+      value: |
+        ## Describe the bug
+        A clear and concise description of what the bug is.
+
+        ## Steps to reproduce
+        1. 
+        2. 
+        3. 
+
+        ## Expected behavior
+        What you expected to happen.
+
+        ## Actual behavior
+        What actually happened (include error messages, stack traces, logs).
+
+        ## Deployment type
+        (Docker Compose / Kubernetes / Managed / Slack / Other)
+
+        ## Environment
+        - IncidentFox version:
+        - Python version:
+        - OS:
+        - Integrations:
+
+        ## Relevant logs
+        (Paste logs here, sanitize sensitive info)
+
+        ## Additional context
+        Any other context about the problem.
+
+        ## Checklist
+        - [ ] I have searched existing issues
+        - [ ] I have provided all requested information
     validations:
       required: true
-
-  - type: textarea
-    id: reproduce
-    attributes:
-      label: Steps to reproduce
-      description: Steps to reproduce the behavior
-      placeholder: |
-        1. Set up IncidentFox with '...'
-        2. Run command '...'
-        3. See error
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected behavior
-      description: What you expected to happen
-      placeholder: Tell us what you expected
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual
-    attributes:
-      label: Actual behavior
-      description: What actually happened (include error messages, stack traces, logs)
-      placeholder: Tell us what happened instead
-      render: shell
-    validations:
-      required: true
-
-  - type: dropdown
-    id: deployment
-    attributes:
-      label: Deployment type
-      description: How are you running IncidentFox?
-      options:
-        - Docker Compose (local)
-        - Kubernetes (self-hosted)
-        - Managed (SaaS)
-        - Slack community instance
-        - Other (please specify)
-    validations:
-      required: true
-
-  - type: textarea
-    id: environment
-    attributes:
-      label: Environment
-      description: |
-        Please provide details about your environment:
-        - IncidentFox version (git commit or release tag)
-        - Python version
-        - Operating system
-        - Any relevant integrations (Datadog, Grafana, etc.)
-      placeholder: |
-        - IncidentFox version: v1.2.3 or commit abc123
-        - Python: 3.11.5
-        - OS: Ubuntu 22.04 / macOS 14 / etc.
-        - Integrations: Datadog, Kubernetes, etc.
-      render: markdown
-    validations:
-      required: true
-
-  - type: textarea
-    id: logs
-    attributes:
-      label: Relevant logs
-      description: Please paste any relevant logs (sanitize sensitive information)
-      render: shell
-
-  - type: textarea
-    id: additional
-    attributes:
-      label: Additional context
-      description: Any other context about the problem (screenshots, related issues, etc.)
-
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Checklist
-      options:
-        - label: I have searched existing issues to avoid duplicates
-          required: true
-        - label: I have provided all requested information
-          required: true


### PR DESCRIPTION
## Description

Reduced the GitHub bug report template to only include title and description to make issue reporting faster

I have included the other details field in the description section as a template placeholder text