### PR TITLE
fix: add read-only validation to BigQuery and Snowflake query scripts

### DIFF
--- a/sre-agent/.claude/skills/database-bigquery/SKILL.md
+++ b/sre-agent/.claude/skills/database-bigquery/SKILL.md
@@ -24,6 +24,14 @@ Configuration environment variables you CAN check (non-secret):
 LIST DATASETS → LIST TABLES → GET TABLE SCHEMA → QUERY
 ```
 
+## Safety Constraints
+
+- **Read-only**: Only SELECT, SHOW, DESCRIBE, WITH are allowed. DML/DDL (INSERT, UPDATE, DELETE, DROP, etc.) is blocked.
+- **Cost control**: Queries are capped at 10 GB bytes billed by default. Override with `--max-bytes-billed` only when justified.
+- **ALWAYS add LIMIT**: BigQuery scans entire partitions. Never run `SELECT *` without LIMIT and a WHERE clause on the partition key.
+- **Use partition filters**: For time-partitioned tables, always filter on `_PARTITIONTIME` or the partition column to avoid full-table scans.
+- **Start small**: Use `--max-results 100` first, increase only if the initial results are insufficient.
+
 ## Available Scripts
 
 All scripts are in `.claude/skills/database-bigquery/scripts/`
@@ -43,29 +51,41 @@ python .claude/skills/database-bigquery/scripts/list_tables.py --dataset DATASET
 python .claude/skills/database-bigquery/scripts/get_table_schema.py --dataset DATASET_ID --table TABLE_ID
 ```
 
-### query.py - Run SQL Queries
+### query.py - Run SQL Queries (read-only)
 ```bash
-python .claude/skills/database-bigquery/scripts/query.py --query "SELECT * FROM dataset.table LIMIT 10" [--dataset DEFAULT_DATASET] [--max-results 1000]
+python .claude/skills/database-bigquery/scripts/query.py --query "SELECT * FROM dataset.table WHERE _PARTITIONTIME >= TIMESTAMP('2026-03-01') LIMIT 10" [--dataset DEFAULT_DATASET] [--max-results 1000] [--max-bytes-billed 10737418240]
 ```
+
+**IMPORTANT**: Always include LIMIT and partition filters. Queries without these on large tables will be expensive.
 
 ---
 
 ## BigQuery SQL Reference
 
 ```sql
--- Standard SQL (default)
+-- Standard SQL (default) — ALWAYS include LIMIT
 SELECT * FROM `project.dataset.table` LIMIT 10
 
--- Aggregate with time
+-- Aggregate with time — use partition filter to control cost
 SELECT DATE(timestamp), COUNT(*) as events
 FROM `dataset.events`
 WHERE timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
 GROUP BY 1 ORDER BY 1 DESC
 
--- Partitioned table query (cost-efficient)
+-- Partitioned table query (cost-efficient) — MANDATORY for large tables
 SELECT * FROM `dataset.events`
 WHERE _PARTITIONTIME >= TIMESTAMP('2026-01-01')
+LIMIT 100
 ```
+
+---
+
+## Anti-Patterns to Avoid
+
+1. ❌ **`SELECT * FROM table`** without LIMIT — scans entire table, potentially TBs
+2. ❌ **Missing partition filter** — on partitioned tables, always filter by partition key
+3. ❌ **`COUNT(*)` on huge tables** without WHERE — use approximate: `APPROX_COUNT_DISTINCT()`
+4. ❌ **Skipping schema inspection** — always run `get_table_schema.py` first to understand columns and partitioning
 
 ---
 

--- a/sre-agent/.claude/skills/database-bigquery/scripts/query.py
+++ b/sre-agent/.claude/skills/database-bigquery/scripts/query.py
@@ -1,22 +1,54 @@
 #!/usr/bin/env python3
-"""Execute a SQL query on BigQuery."""
+"""Execute a read-only SQL query on BigQuery.
+
+Security: Only SELECT, SHOW, DESCRIBE, and WITH statements are allowed.
+DML/DDL (INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, MERGE, TRUNCATE, etc.)
+is blocked to prevent data modification and unexpected cost.
+"""
 
 import argparse
+import re
 import sys
 
 from bq_client import format_output, get_client, get_config
 
+# Allowed read-only statement types (case-insensitive, anchored to start of query)
+_READONLY_PATTERN = re.compile(r"^\s*(SELECT|SHOW|DESCRIBE|WITH)\b", re.IGNORECASE)
+
+# Maximum bytes that a query is allowed to scan (10 GB)
+_MAX_BYTES_BILLED = 10 * 1024 * 1024 * 1024
+
+
+def _validate_readonly(query: str) -> None:
+    """Reject non-read-only statements."""
+    if not _READONLY_PATTERN.match(query):
+        raise ValueError(
+            "Only read-only queries are allowed (SELECT, SHOW, DESCRIBE, WITH). "
+            "DML/DDL statements are blocked for safety."
+        )
+    # Block semicolons that could enable multi-statement injection
+    # (allow trailing semicolon only)
+    stripped = query.rstrip().rstrip(";").rstrip()
+    if ";" in stripped:
+        raise ValueError("Multi-statement queries are not allowed. Submit one query at a time.")
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Execute BigQuery query")
+    parser = argparse.ArgumentParser(description="Execute BigQuery query (read-only)")
     parser.add_argument("--query", required=True, help="SQL query to execute")
     parser.add_argument("--dataset", help="Default dataset")
+    parser.add_argument("--max-results", type=int, default=1000, help="Max rows (default: 1000)")
     parser.add_argument(
-        "--max-results", type=int, default=1000, help="Max rows (default: 1000)"
+        "--max-bytes-billed",
+        type=int,
+        default=_MAX_BYTES_BILLED,
+        help=f"Max bytes billed safety cap (default: {_MAX_BYTES_BILLED // (1024**3)} GB)",
     )
     args = parser.parse_args()
 
     try:
+        _validate_readonly(args.query)
+
         from google.cloud import bigquery
 
         client = get_client()
@@ -24,11 +56,11 @@ def main():
 
         default_dataset = args.dataset or config.get("dataset")
 
-        job_config = None
+        job_config = bigquery.QueryJobConfig(
+            maximum_bytes_billed=args.max_bytes_billed,
+        )
         if default_dataset:
-            job_config = bigquery.QueryJobConfig(
-                default_dataset=f"{config['project_id']}.{default_dataset}"
-            )
+            job_config.default_dataset = f"{config['project_id']}.{default_dataset}"
 
         query_job = client.query(args.query, job_config=job_config)
         results = query_job.result(max_results=args.max_results)
@@ -43,8 +75,7 @@ def main():
                     "row_count": len(rows),
                     "total_rows": results.total_rows,
                     "schema": [
-                        {"name": field.name, "type": field.field_type}
-                        for field in results.schema
+                        {"name": field.name, "type": field.field_type} for field in results.schema
                     ],
                     "rows": rows,
                 }

--- a/sre-agent/.claude/skills/database-snowflake/SKILL.md
+++ b/sre-agent/.claude/skills/database-snowflake/SKILL.md
@@ -26,6 +26,13 @@ Configuration environment variables you CAN check (non-secret):
 GET SCHEMA / LIST TABLES → DESCRIBE TABLE → EXECUTE QUERY
 ```
 
+## Safety Constraints
+
+- **Read-only**: Only SELECT, SHOW, DESCRIBE, LIST, WITH are allowed. DML/DDL (INSERT, UPDATE, DELETE, DROP, etc.) is blocked.
+- **ALWAYS add LIMIT**: Default is 100 rows. Increase only when initial results are insufficient.
+- **Use time filters**: For time-series tables, always include a WHERE clause on the timestamp/date column to avoid scanning full history.
+- **Start with aggregations**: Use COUNT/GROUP BY to understand data shape before fetching raw rows.
+
 ## Available Scripts
 
 All scripts are in `.claude/skills/database-snowflake/scripts/`
@@ -45,10 +52,12 @@ python .claude/skills/database-snowflake/scripts/list_tables.py [--database DB] 
 python .claude/skills/database-snowflake/scripts/describe_table.py --table TABLE_NAME [--database DB] [--schema SCHEMA]
 ```
 
-### execute_query.py - Run SQL Queries
+### execute_query.py - Run SQL Queries (read-only)
 ```bash
 python .claude/skills/database-snowflake/scripts/execute_query.py --query "SELECT * FROM fact_incident ORDER BY started_at DESC LIMIT 10" [--limit 100]
 ```
+
+**IMPORTANT**: Only read-only queries (SELECT, SHOW, DESCRIBE, LIST, WITH) are allowed. DML/DDL is blocked.
 
 ---
 

--- a/sre-agent/.claude/skills/database-snowflake/scripts/execute_query.py
+++ b/sre-agent/.claude/skills/database-snowflake/scripts/execute_query.py
@@ -1,21 +1,44 @@
 #!/usr/bin/env python3
-"""Execute a SQL query against Snowflake."""
+"""Execute a read-only SQL query against Snowflake.
+
+Security: Only SELECT, SHOW, DESCRIBE, LIST, and WITH statements are allowed.
+DML/DDL (INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, MERGE, TRUNCATE, etc.)
+is blocked to prevent data modification.
+"""
 
 import argparse
+import re
 import sys
 
 from snowflake_client import format_output, get_connection
 
+# Allowed read-only statement types (case-insensitive, anchored to start of query)
+_READONLY_PATTERN = re.compile(r"^\s*(SELECT|SHOW|DESCRIBE|DESC|LIST|WITH)\b", re.IGNORECASE)
+
+
+def _validate_readonly(query: str) -> None:
+    """Reject non-read-only statements."""
+    if not _READONLY_PATTERN.match(query):
+        raise ValueError(
+            "Only read-only queries are allowed (SELECT, SHOW, DESCRIBE, LIST, WITH). "
+            "DML/DDL statements are blocked for safety."
+        )
+    # Block semicolons that could enable multi-statement injection
+    # (allow trailing semicolon only)
+    stripped = query.rstrip().rstrip(";").rstrip()
+    if ";" in stripped:
+        raise ValueError("Multi-statement queries are not allowed. Submit one query at a time.")
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Execute Snowflake query")
+    parser = argparse.ArgumentParser(description="Execute Snowflake query (read-only)")
     parser.add_argument("--query", required=True, help="SQL query to execute")
-    parser.add_argument(
-        "--limit", type=int, default=100, help="Max rows to return (default: 100)"
-    )
+    parser.add_argument("--limit", type=int, default=100, help="Max rows to return (default: 100)")
     args = parser.parse_args()
 
     try:
+        _validate_readonly(args.query)
+
         conn = get_connection()
         cursor = conn.cursor()
 


### PR DESCRIPTION
## Summary

BigQuery and Snowflake query scripts lacked the read-only validation and safety constraints that PostgreSQL and MySQL already had. This PR brings them to parity:

- **`query.py` (BigQuery)**: Added `_validate_readonly()` regex whitelist (SELECT/SHOW/DESCRIBE/WITH), multi-statement injection blocking, and `maximum_bytes_billed` cost cap (default 10 GB)
- **`execute_query.py` (Snowflake)**: Added `_validate_readonly()` regex whitelist (SELECT/SHOW/DESCRIBE/DESC/LIST/WITH) and multi-statement injection blocking
- **SKILL.md (both)**: Added safety constraints section guiding the agent to use LIMIT, partition/time filters, schema-first investigation, and start with aggregations

## Motivation

The PostgreSQL and MySQL database skills already enforce read-only queries and block multi-statement injection. BigQuery and Snowflake were missing these protections, creating an inconsistent security posture across database skills. Without these guards, the agent could accidentally execute DML/DDL or run unbounded queries causing cost spikes.

## Changes

| File | Change |
|------|--------|
| `sre-agent/.claude/skills/database-bigquery/scripts/query.py` | Add `_validate_readonly()`, `_MAX_BYTES_BILLED`, `--max-bytes-billed` CLI arg |
| `sre-agent/.claude/skills/database-snowflake/scripts/execute_query.py` | Add `_validate_readonly()` with Snowflake-specific keywords (LIST, DESC) |
| `sre-agent/.claude/skills/database-bigquery/SKILL.md` | Add Safety Constraints, Anti-Patterns, partition filter guidance |
| `sre-agent/.claude/skills/database-snowflake/SKILL.md` | Add Safety Constraints, time filter and aggregation guidance |

## Test plan

- [x] `ruff check` passes on both modified Python files
- [x] `ruff format --check` passes on both modified Python files
- [ ] Existing BigQuery read-only queries (SELECT/WITH) continue to work unchanged
- [ ] Existing Snowflake read-only queries (SELECT/SHOW/DESCRIBE/LIST/WITH) continue to work unchanged
- [ ] DML/DDL statements (INSERT/UPDATE/DELETE/DROP) are rejected with clear error message
- [ ] Multi-statement queries (e.g. `SELECT 1; DROP TABLE x`) are rejected
- [ ] BigQuery queries respect `maximum_bytes_billed` cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)