### PR TITLE
fix: add query safety guards to observability and Azure skills

### DIFF
--- a/sre-agent/.claude/skills/infrastructure-azure/SKILL.md
+++ b/sre-agent/.claude/skills/infrastructure-azure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-infrastructure
-description: Azure cloud infrastructure inspection. Use when investigating Azure VMs, AKS clusters, Log Analytics (KQL), Monitor metrics/alerts, Cost Management, or NSG rules.
+description: Azure infrastructure inspection (KQL, Monitor, Resource Graph). KQL results auto-capped at 1000 rows. Always use time filters and `| limit N`.
 allowed-tools: Bash(python *)
 ---
 
@@ -16,14 +16,6 @@ Configuration environment variables you CAN check (non-secret):
 
 ---
 
-## Safety Constraints
-
-- **KQL result limits**: Queries are automatically capped at 1000 rows by default. Override with `--max-results` (max: 10000). Always include `| limit N` or `| take N` in KQL for explicit control.
-- **Always use time filters**: Default timespan is 24h. Use `--timespan PT1H` for shorter scans. Never query without a time range.
-- **Start with aggregations**: Use `| summarize count() by ...` before fetching raw rows to understand data shape.
-- **Resource Graph queries**: Always include `| limit N` to prevent returning all resources across subscriptions.
-- **Cost queries**: Always specify `--start` and `--end` date range.
-
 ## MANDATORY: Query-First Investigation
 
 **Start with Log Analytics or Monitor metrics, then drill into resources.**
@@ -31,6 +23,8 @@ Configuration environment variables you CAN check (non-secret):
 ```
 LOG ANALYTICS / METRICS → IDENTIFY RESOURCE → DESCRIBE RESOURCE → CHECK ALERTS
 ```
+
+**Limits:** KQL results auto-capped at 1000 rows (override with `--max-results`, max 10000). Always include `| limit N` in KQL and `--timespan` for time control. Use `| summarize` before fetching raw rows.
 
 ## Available Scripts
 

--- a/sre-agent/.claude/skills/infrastructure-azure/SKILL.md
+++ b/sre-agent/.claude/skills/infrastructure-azure/SKILL.md
@@ -78,17 +78,17 @@ python .claude/skills/infrastructure-azure/scripts/get_nsg_rules.py --resource-g
 ## KQL Query Reference
 
 ```kql
-// Errors in last hour
+// Errors in last hour (always include | limit)
 AzureDiagnostics | where Level == "Error" | where TimeGenerated > ago(1h) | limit 50
 
-// CPU usage
+// CPU usage (summarize is bounded, no limit needed)
 Perf | where CounterName == "% Processor Time" | summarize avg(CounterValue) by bin(TimeGenerated, 5m), Computer
 
 // Heartbeat (availability)
 Heartbeat | summarize count() by Computer, bin(TimeGenerated, 1h)
 
-// Resource Graph - find VMs
-Resources | where type == "microsoft.compute/virtualmachines" | project name, location, properties.hardwareProfile.vmSize
+// Resource Graph - find VMs (always include | limit)
+Resources | where type == "microsoft.compute/virtualmachines" | project name, location, properties.hardwareProfile.vmSize | limit 100
 ```
 
 ---

--- a/sre-agent/.claude/skills/infrastructure-azure/SKILL.md
+++ b/sre-agent/.claude/skills/infrastructure-azure/SKILL.md
@@ -16,6 +16,14 @@ Configuration environment variables you CAN check (non-secret):
 
 ---
 
+## Safety Constraints
+
+- **KQL result limits**: Queries are automatically capped at 1000 rows by default. Override with `--max-results` (max: 10000). Always include `| limit N` or `| take N` in KQL for explicit control.
+- **Always use time filters**: Default timespan is 24h. Use `--timespan PT1H` for shorter scans. Never query without a time range.
+- **Start with aggregations**: Use `| summarize count() by ...` before fetching raw rows to understand data shape.
+- **Resource Graph queries**: Always include `| limit N` to prevent returning all resources across subscriptions.
+- **Cost queries**: Always specify `--start` and `--end` date range.
+
 ## MANDATORY: Query-First Investigation
 
 **Start with Log Analytics or Monitor metrics, then drill into resources.**

--- a/sre-agent/.claude/skills/infrastructure-azure/scripts/query_log_analytics.py
+++ b/sre-agent/.claude/skills/infrastructure-azure/scripts/query_log_analytics.py
@@ -1,25 +1,53 @@
 #!/usr/bin/env python3
-"""Query Azure Log Analytics using KQL."""
+"""Query Azure Log Analytics using KQL.
+
+Safety: Queries are automatically capped with a `| limit` clause to prevent
+unbounded result sets. The default cap is 1000 rows.
+"""
 
 import argparse
+import re
 import sys
 from datetime import datetime, timedelta
 
 from azure_client import format_output, get_credentials
 
+# Maximum rows to return from a KQL query (safety cap)
+_DEFAULT_MAX_RESULTS = 1000
+_ABSOLUTE_MAX_RESULTS = 10000
+
+
+def _ensure_kql_limit(query: str, max_results: int) -> str:
+    """Append a '| limit N' clause to KQL if no limit/take is present.
+
+    This prevents unbounded queries from returning millions of rows.
+    """
+    # Check if query already contains a limit/take clause (case-insensitive)
+    # Match patterns like: | limit 50, | take 100
+    if re.search(r"\|\s*(limit|take)\s+\d+", query, re.IGNORECASE):
+        return query
+    # Also check if query ends with a summarize/count (aggregations are bounded)
+    if re.search(r"\|\s*(summarize|count)\b", query, re.IGNORECASE):
+        return query
+    return f"{query.rstrip().rstrip(';')} | limit {max_results}"
+
 
 def main():
     parser = argparse.ArgumentParser(description="Query Azure Log Analytics")
-    parser.add_argument(
-        "--workspace-id", required=True, help="Log Analytics workspace ID (GUID)"
-    )
+    parser.add_argument("--workspace-id", required=True, help="Log Analytics workspace ID (GUID)")
     parser.add_argument("--query", required=True, help="KQL query string")
+    parser.add_argument("--timespan", help="ISO 8601 duration (e.g., PT1H, P1D). Default: PT24H")
     parser.add_argument(
-        "--timespan", help="ISO 8601 duration (e.g., PT1H, P1D). Default: PT24H"
+        "--max-results",
+        type=int,
+        default=_DEFAULT_MAX_RESULTS,
+        help=f"Max rows to return (default: {_DEFAULT_MAX_RESULTS}, max: {_ABSOLUTE_MAX_RESULTS})",
     )
     args = parser.parse_args()
 
     try:
+        max_results = min(args.max_results, _ABSOLUTE_MAX_RESULTS)
+
         from azure.monitor.query import LogsQueryClient
 
         credential = get_credentials()
@@ -27,9 +55,12 @@ def main():
 
         timespan = args.timespan if args.timespan else timedelta(hours=24)
 
+        # Ensure query has a result limit to prevent unbounded scans
+        safe_query = _ensure_kql_limit(args.query, max_results)
+
         response = client.query_workspace(
             workspace_id=args.workspace_id,
-            query=args.query,
+            query=safe_query,
             timespan=timespan,
         )
 
@@ -45,15 +76,13 @@ def main():
                             value = value.isoformat()
                         row_dict[column.name] = value
                     rows.append(row_dict)
-                tables.append(
-                    {"name": table.name, "row_count": len(rows), "rows": rows}
-                )
+                tables.append({"name": table.name, "row_count": len(rows), "rows": rows})
 
             print(
                 format_output(
                     {
                         "workspace_id": args.workspace_id,
-                        "query": args.query,
+                        "query": safe_query,
                         "status": "Success",
                         "tables": tables,
                     }
@@ -64,7 +93,7 @@ def main():
                 format_output(
                     {
                         "workspace_id": args.workspace_id,
-                        "query": args.query,
+                        "query": safe_query,
                         "status": "Partial",
                         "error": "Partial results or query timeout",
                     }

--- a/sre-agent/.claude/skills/observability-datadog/SKILL.md
+++ b/sre-agent/.claude/skills/observability-datadog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: datadog-analysis
-description: Datadog log and metrics analysis. Use when querying Datadog logs, metrics, or APM data. Provides scripts and query syntax reference.
+description: Datadog log and metrics analysis. Time-capped (max 24h), result-capped (max 1000). ALWAYS run get_statistics.py before sampling logs.
 allowed-tools: Bash(python *)
 ---
 
@@ -203,7 +203,7 @@ p95:trace.http.request.duration{service:X}
 ## Anti-Patterns to Avoid
 
 1. ❌ **NEVER skip statistics** - `get_statistics.py` is MANDATORY first step
-2. ❌ **Unbounded queries** - Always specify time ranges and limits
-3. ❌ **Fetching all logs** - Use sampling strategies, not unbounded searches
+2. ❌ **Time range too wide** - Max 24h (1440 min). Start with `--time-range 60`, expand if needed
+3. ❌ **Too many raw logs** - Max 1000 per query. Use strategies like `errors_only` to narrow scope
 4. ❌ **Ignoring error rate** - High error rate means immediate investigation
-5. ❌ **Missing service filter** - For multi-service apps, always filter by service
+5. ❌ **Missing service filter** - Always use `--service X` for multi-service apps

--- a/sre-agent/.claude/skills/observability-datadog/scripts/sample_logs.py
+++ b/sre-agent/.claude/skills/observability-datadog/scripts/sample_logs.py
@@ -20,10 +20,30 @@ Examples:
 
 import argparse
 import json
+import re
 import sys
 from datetime import datetime, timedelta
 
 from datadog_client import format_log_entry, search_logs
+
+# Only allow safe characters in Datadog facet values to prevent query injection.
+_SAFE_DD_FACET = re.compile(r"^[a-zA-Z0-9_\-.*]+$")
+
+# Maximum time range in minutes (24 hours)
+_MAX_TIME_RANGE_MINUTES = 1440
+
+# Maximum result limit
+_MAX_LIMIT = 1000
+
+
+def _validate_dd_facet(value: str, facet_name: str) -> str:
+    """Validate a Datadog facet value to prevent query injection."""
+    if not _SAFE_DD_FACET.match(value):
+        raise ValueError(
+            f"Invalid {facet_name} value: '{value}'. "
+            f"Only alphanumeric, underscore, hyphen, dot, and wildcard (*) are allowed."
+        )
+    return value
 
 
 def main():
@@ -58,13 +78,20 @@ def main():
     args = parser.parse_args()
 
     try:
-        # Build query based on strategy
+        # Enforce safety limits
+        if args.time_range > _MAX_TIME_RANGE_MINUTES:
+            raise ValueError(
+                f"Time range {args.time_range}m exceeds maximum ({_MAX_TIME_RANGE_MINUTES}m / 24h)."
+            )
+        args.limit = min(args.limit, _MAX_LIMIT)
+
+        # Build query based on strategy with validated facets
         query_parts = []
 
         if args.service:
-            query_parts.append(f"service:{args.service}")
+            query_parts.append(f"service:{_validate_dd_facet(args.service, 'service')}")
         if args.host:
-            query_parts.append(f"host:{args.host}")
+            query_parts.append(f"host:{_validate_dd_facet(args.host, 'host')}")
 
         # Apply strategy filter
         if args.strategy == "errors_only":
@@ -104,10 +131,7 @@ def main():
                     if log.get("timestamp")
                     and abs(
                         (
-                            datetime.fromisoformat(
-                                log["timestamp"].replace("Z", "+00:00")
-                            )
-                            - target
+                            datetime.fromisoformat(log["timestamp"].replace("Z", "+00:00")) - target
                         ).total_seconds()
                     )
                     <= window.total_seconds()

--- a/sre-agent/.claude/skills/observability-elasticsearch/SKILL.md
+++ b/sre-agent/.claude/skills/observability-elasticsearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elasticsearch-analysis
-description: Elasticsearch/OpenSearch log analysis using Lucene query syntax and Query DSL. Use when investigating issues via ELK stack, OpenSearch, or any Elasticsearch-based logging.
+description: Elasticsearch/OpenSearch log analysis (Lucene/Query DSL). Results capped at 1000 hits. ALWAYS run get_statistics.py before sampling logs.
 allowed-tools: Bash(python *)
 ---
 
@@ -11,14 +11,6 @@ allowed-tools: Bash(python *)
 **IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `ELASTICSEARCH_URL`, `ES_USER`, or `ES_PASSWORD` in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
 
 ---
-
-## Safety Constraints
-
-- **Result size cap**: Search results are capped at 1000 hits. Use aggregations (`size: 0` + `aggs`) for large datasets.
-- **Always use time filters**: Include `@timestamp` range in queries. Default scripts use 60-minute lookback.
-- **Use `.keyword` for aggregations**: Never aggregate on `text` fields — use `field.keyword` suffix.
-- **Avoid wildcard prefix queries**: `*error` is expensive. Prefer `error*` or exact match.
-- **Start with statistics**: `get_statistics.py` is MANDATORY before sampling raw logs.
 
 ## MANDATORY: Statistics-First Investigation
 
@@ -313,8 +305,8 @@ error NOT debug
 ## Anti-Patterns to Avoid
 
 1. ❌ **NEVER skip statistics** - `get_statistics.py` is MANDATORY first step
-2. ❌ **Unbounded queries** - Always specify time ranges and limits
-3. ❌ **Fetching all logs** - Use sampling strategies, not unbounded searches
+2. ❌ **Missing time filter** - Always include `@timestamp` range. Default lookback is 60 min
+3. ❌ **Too many hits** - Results capped at 1000. Use aggregations (`size: 0` + `aggs`) for large datasets
 4. ❌ **Ignoring error rate** - High error rate means immediate investigation
 5. ❌ **Text field in aggregation** - Use `.keyword` suffix for terms aggs
 6. ❌ **Wildcard prefix** - `*error` is expensive, prefer `error*` or exact match

--- a/sre-agent/.claude/skills/observability-elasticsearch/SKILL.md
+++ b/sre-agent/.claude/skills/observability-elasticsearch/SKILL.md
@@ -12,6 +12,14 @@ allowed-tools: Bash(python *)
 
 ---
 
+## Safety Constraints
+
+- **Result size cap**: Search results are capped at 1000 hits. Use aggregations (`size: 0` + `aggs`) for large datasets.
+- **Always use time filters**: Include `@timestamp` range in queries. Default scripts use 60-minute lookback.
+- **Use `.keyword` for aggregations**: Never aggregate on `text` fields — use `field.keyword` suffix.
+- **Avoid wildcard prefix queries**: `*error` is expensive. Prefer `error*` or exact match.
+- **Start with statistics**: `get_statistics.py` is MANDATORY before sampling raw logs.
+
 ## MANDATORY: Statistics-First Investigation
 
 **NEVER dump raw logs.** Always follow this pattern:

--- a/sre-agent/.claude/skills/observability-elasticsearch/scripts/elasticsearch_client.py
+++ b/sre-agent/.claude/skills/observability-elasticsearch/scripts/elasticsearch_client.py
@@ -121,6 +121,9 @@ def get_headers() -> dict[str, str]:
     return headers
 
 
+_MAX_SEARCH_SIZE = 1000
+
+
 def search(
     query: dict[str, Any],
     index: str | None = None,
@@ -132,7 +135,7 @@ def search(
     Args:
         query: Elasticsearch query DSL (the "query" part)
         index: Index pattern (default: from config)
-        size: Maximum results to return (default: 100)
+        size: Maximum results to return (default: 100, capped at 1000)
         sort: Sort specification (default: @timestamp desc)
 
     Returns:
@@ -143,6 +146,9 @@ def search(
     """
     config = get_config()
     index = index or config.get("index_pattern", "logs-*")
+
+    # Cap size to prevent unbounded result sets that could OOM the cluster
+    size = min(size, _MAX_SEARCH_SIZE)
 
     url = get_api_url(f"/{index}/_search")
 

--- a/sre-agent/.claude/skills/observability-loki/SKILL.md
+++ b/sre-agent/.claude/skills/observability-loki/SKILL.md
@@ -8,6 +8,14 @@ allowed-tools:
 
 Query and analyze logs from Grafana Loki for incident investigation and debugging.
 
+## Safety Constraints
+
+- **Always use stream selectors**: Never query without `{app="..."}` or `{namespace="..."}` — bare queries scan all streams.
+- **Limit results**: Default is 20 entries. Increase only when initial results are insufficient (max: 1000).
+- **Use time filters**: Default lookback is 1 hour. Maximum is 7 days. Start small, expand if needed.
+- **Start with statistics**: Run `get_statistics.py` first to understand volume before sampling raw logs.
+- **Simple filter patterns only**: Use keywords like `error|exception`, not complex regex.
+
 ## Investigation Workflow
 
 1. **List available labels** to understand what's queryable

--- a/sre-agent/.claude/skills/observability-loki/SKILL.md
+++ b/sre-agent/.claude/skills/observability-loki/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Query and analyze logs from Grafana Loki using LogQL
+description: Grafana Loki log analysis (LogQL). Results capped at 1000, lookback max 7 days. Always use stream selectors and get_statistics.py first.
 allowed-tools:
   - Bash
 ---
@@ -8,20 +8,14 @@ allowed-tools:
 
 Query and analyze logs from Grafana Loki for incident investigation and debugging.
 
-## Safety Constraints
-
-- **Always use stream selectors**: Never query without `{app="..."}` or `{namespace="..."}` — bare queries scan all streams.
-- **Limit results**: Default is 20 entries. Increase only when initial results are insufficient (max: 1000).
-- **Use time filters**: Default lookback is 1 hour. Maximum is 7 days. Start small, expand if needed.
-- **Start with statistics**: Run `get_statistics.py` first to understand volume before sampling raw logs.
-- **Simple filter patterns only**: Use keywords like `error|exception`, not complex regex.
-
 ## Investigation Workflow
 
 1. **List available labels** to understand what's queryable
-2. **Get statistics** to understand log volume and error rates
-3. **Sample logs** to see representative entries
-4. **Query specific patterns** with LogQL
+2. **Get statistics** (`get_statistics.py`) to understand volume before sampling
+3. **Sample logs** with simple keyword filters like `error|exception`
+4. **Query specific patterns** with LogQL — always include a stream selector (`{app="..."}`)
+
+**Limits:** Default 20 entries (max 1000). Default lookback 1h (max 7 days). Start small, expand if needed.
 
 ## LogQL Quick Reference
 

--- a/sre-agent/.claude/skills/observability-loki/scripts/sample_logs.py
+++ b/sre-agent/.claude/skills/observability-loki/scripts/sample_logs.py
@@ -3,10 +3,37 @@
 
 import argparse
 import json
+import re
 import sys
 from datetime import datetime, timedelta, timezone
 
 from loki_client import format_log_entry, query
+
+# Maximum lookback hours to prevent scanning excessive log history (7 days)
+_MAX_LOOKBACK_HOURS = 168
+
+# Maximum result limit
+_MAX_LIMIT = 1000
+
+# Characters that are safe in LogQL line filter patterns.
+# Allow alphanumeric, common log keywords, and basic regex alternation (|).
+# Block characters that could break out of the quoted context or inject LogQL.
+_SAFE_LOGQL_FILTER = re.compile(r"^[a-zA-Z0-9_\-.*|:/ ]+$")
+
+
+def _validate_logql_filter(pattern: str) -> str:
+    """Validate and escape a LogQL line filter pattern to prevent injection.
+
+    Only simple keyword/alternation patterns are allowed (e.g., 'error|exception').
+    Complex regex or LogQL syntax characters are rejected.
+    """
+    if not _SAFE_LOGQL_FILTER.match(pattern):
+        raise ValueError(
+            f"Invalid filter pattern: '{pattern}'. "
+            f"Only alphanumeric, underscore, hyphen, dot, pipe (|), colon, slash, "
+            f"and space are allowed. Use simple keywords like 'error|exception'."
+        )
+    return pattern
 
 
 def main():
@@ -39,10 +66,19 @@ def main():
     args = parser.parse_args()
 
     try:
-        # Build query
+        # Enforce safety limits
+        if args.lookback > _MAX_LOOKBACK_HOURS:
+            raise ValueError(
+                f"Lookback {args.lookback}h exceeds maximum ({_MAX_LOOKBACK_HOURS}h / 7 days). "
+                f"Use a shorter window."
+            )
+        args.limit = min(args.limit, _MAX_LIMIT)
+
+        # Build query with validated filter
         logql = args.selector
         if args.filter:
-            logql = f'{args.selector} |~ "{args.filter}"'
+            safe_filter = _validate_logql_filter(args.filter)
+            logql = f'{args.selector} |~ "{safe_filter}"'
 
         now = datetime.now(timezone.utc)
         start = now - timedelta(hours=args.lookback)
@@ -104,9 +140,7 @@ def main():
                 print()
 
             print("-" * 60)
-            print(
-                f"Showing {min(len(all_entries), args.limit)} of {len(all_entries)} entries"
-            )
+            print(f"Showing {min(len(all_entries), args.limit)} of {len(all_entries)} entries")
 
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/sre-agent/.claude/skills/observability-splunk/SKILL.md
+++ b/sre-agent/.claude/skills/observability-splunk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: splunk-analysis
-description: Splunk log analysis using SPL (Search Processing Language). Use when investigating issues via Splunk logs, saved searches, or alerts.
+description: Splunk log analysis (SPL). Read-only, time-capped (max 24h), result-capped (max 500). ALWAYS run get_statistics.py before sampling logs.
 allowed-tools: Bash(python *)
 ---
 
@@ -11,14 +11,6 @@ allowed-tools: Bash(python *)
 **IMPORTANT**: Credentials are injected automatically by a proxy layer. Do NOT check for `SPLUNK_HOST`, `SPLUNK_TOKEN`, or other credentials in environment variables - they won't be visible to you. Just run the scripts directly; authentication is handled transparently.
 
 ---
-
-## Safety Constraints
-
-- **Always specify index**: Use `--index` to target a specific index. Querying `index=*` scans all data.
-- **Time range cap**: Maximum 24 hours per query (1440 minutes). Start with 60 minutes, expand if needed.
-- **Result limit**: Default 50 entries, maximum 500. Use aggregations (`stats`, `timechart`) instead of raw log dumps.
-- **Input validation**: Index, sourcetype, and host values are validated — only alphanumeric, underscore, hyphen, dot, and wildcard are allowed.
-- **Start with statistics**: `get_statistics.py` is MANDATORY before sampling raw logs.
 
 ## MANDATORY: Statistics-First Investigation
 
@@ -250,8 +242,8 @@ index=main
 ## Anti-Patterns to Avoid
 
 1. ❌ **NEVER skip statistics** - `get_statistics.py` is MANDATORY first step
-2. ❌ **No index specified** - Always use `index=X` for performance
-3. ❌ **Unbounded time range** - Always specify time ranges
-4. ❌ **Fetching all logs** - Use sampling strategies, not unbounded searches
+2. ❌ **No index specified** - Always use `--index X`. `index=*` scans all data
+3. ❌ **Time range too wide** - Max 24h (1440 min). Start with `--time-range 60`, expand if needed
+4. ❌ **Too many raw logs** - Max 500 per query. Use `stats`/`timechart` for large volumes
 5. ❌ **Ignoring error rate** - High error rate means immediate investigation
 6. ❌ **Complex rex on all events** - Filter first, then extract

--- a/sre-agent/.claude/skills/observability-splunk/SKILL.md
+++ b/sre-agent/.claude/skills/observability-splunk/SKILL.md
@@ -12,6 +12,14 @@ allowed-tools: Bash(python *)
 
 ---
 
+## Safety Constraints
+
+- **Always specify index**: Use `--index` to target a specific index. Querying `index=*` scans all data.
+- **Time range cap**: Maximum 24 hours per query (1440 minutes). Start with 60 minutes, expand if needed.
+- **Result limit**: Default 50 entries, maximum 500. Use aggregations (`stats`, `timechart`) instead of raw log dumps.
+- **Input validation**: Index, sourcetype, and host values are validated — only alphanumeric, underscore, hyphen, dot, and wildcard are allowed.
+- **Start with statistics**: `get_statistics.py` is MANDATORY before sampling raw logs.
+
 ## MANDATORY: Statistics-First Investigation
 
 **NEVER dump raw logs.** Always follow this pattern:

--- a/sre-agent/.claude/skills/observability-splunk/SKILL.md
+++ b/sre-agent/.claude/skills/observability-splunk/SKILL.md
@@ -73,10 +73,7 @@ python .claude/skills/observability-splunk/scripts/sample_logs.py --strategy all
 ### Basic Search
 
 ```spl
-# Simple keyword search
-error
-
-# Index specific search (ALWAYS specify index for performance)
+# ALWAYS specify index for performance
 index=main error
 
 # Multiple keywords (implicit AND)

--- a/sre-agent/.claude/skills/observability-splunk/scripts/get_statistics.py
+++ b/sre-agent/.claude/skills/observability-splunk/scripts/get_statistics.py
@@ -18,10 +18,28 @@ Examples:
 
 import argparse
 import json
+import re
 import sys
 from collections import Counter
 
 from splunk_client import execute_search
+
+# Only allow safe characters in SPL field values to prevent query injection.
+# Permits alphanumeric, underscore, hyphen, dot, and wildcard (*).
+_SAFE_SPL_FIELD = re.compile(r"^[a-zA-Z0-9_\-.*]+$")
+
+# Maximum time range in minutes to prevent unbounded scans (24 hours)
+_MAX_TIME_RANGE_MINUTES = 1440
+
+
+def _validate_spl_field(value: str, field_name: str) -> str:
+    """Validate a value used in SPL field filters to prevent injection."""
+    if not _SAFE_SPL_FIELD.match(value):
+        raise ValueError(
+            f"Invalid {field_name} value: '{value}'. "
+            f"Only alphanumeric, underscore, hyphen, dot, and wildcard (*) are allowed."
+        )
+    return value
 
 
 def main():
@@ -38,16 +56,23 @@ def main():
     args = parser.parse_args()
 
     try:
-        # Build base search
+        # Cap time range to prevent unbounded scans
+        if args.time_range > _MAX_TIME_RANGE_MINUTES:
+            raise ValueError(
+                f"Time range {args.time_range}m exceeds maximum ({_MAX_TIME_RANGE_MINUTES}m / 24h). "
+                f"Use a shorter range or narrow your search."
+            )
+
+        # Build base search with validated fields
         base_parts = []
         if args.index:
-            base_parts.append(f"index={args.index}")
+            base_parts.append(f"index={_validate_spl_field(args.index, 'index')}")
         else:
             base_parts.append("index=*")
         if args.sourcetype:
-            base_parts.append(f"sourcetype={args.sourcetype}")
+            base_parts.append(f"sourcetype={_validate_spl_field(args.sourcetype, 'sourcetype')}")
         if args.host:
-            base_parts.append(f"host={args.host}")
+            base_parts.append(f"host={_validate_spl_field(args.host, 'host')}")
 
         base_search = " ".join(base_parts)
 
@@ -80,12 +105,8 @@ def main():
             level_dist[level] = count
 
         # 3. Get top sourcetypes
-        sourcetype_query = (
-            f"{base_search} | stats count by sourcetype | sort -count | head 10"
-        )
-        sourcetype_results = execute_search(
-            sourcetype_query, args.time_range, max_results=10
-        )
+        sourcetype_query = f"{base_search} | stats count by sourcetype | sort -count | head 10"
+        sourcetype_results = execute_search(sourcetype_query, args.time_range, max_results=10)
 
         top_sourcetypes = [
             {"sourcetype": r.get("sourcetype"), "count": int(r.get("count", 0))}
@@ -96,13 +117,12 @@ def main():
         host_query = f"{base_search} | stats count by host | sort -count | head 10"
         host_results = execute_search(host_query, args.time_range, max_results=10)
 
-        top_hosts = [
-            {"host": r.get("host"), "count": int(r.get("count", 0))}
-            for r in host_results
-        ]
+        top_hosts = [{"host": r.get("host"), "count": int(r.get("count", 0))} for r in host_results]
 
         # 5. Get sample errors for pattern analysis
-        error_query = f"{base_search} (log_level=ERROR OR log_level=error OR severity=ERROR) | head 50"
+        error_query = (
+            f"{base_search} (log_level=ERROR OR log_level=error OR severity=ERROR) | head 50"
+        )
         error_results = execute_search(error_query, args.time_range, max_results=50)
 
         # Extract unique error patterns
@@ -117,9 +137,7 @@ def main():
                 "<UUID>",
                 str(msg),
             )
-            normalized = re.sub(
-                r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "<IP>", normalized
-            )
+            normalized = re.sub(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b", "<IP>", normalized)
             normalized = re.sub(r"\b\d+\b", "<NUM>", normalized)
             normalized = normalized[:100]
             error_patterns[normalized] += 1
@@ -133,17 +151,17 @@ def main():
         if total_count == 0:
             recommendation = "No logs found in the specified time range."
         elif error_rate > 10:
-            recommendation = f"HIGH error rate ({error_rate}%). Investigate top error patterns immediately."
+            recommendation = (
+                f"HIGH error rate ({error_rate}%). Investigate top error patterns immediately."
+            )
         elif error_rate > 5:
-            recommendation = (
-                f"Elevated error rate ({error_rate}%). Review error patterns."
-            )
+            recommendation = f"Elevated error rate ({error_rate}%). Review error patterns."
         elif total_count > 100000:
-            recommendation = f"Very high volume ({total_count:,} logs). Use targeted sourcetype/index filter."
-        else:
             recommendation = (
-                f"Normal volume ({total_count:,} logs). Error rate: {error_rate}%"
+                f"Very high volume ({total_count:,} logs). Use targeted sourcetype/index filter."
             )
+        else:
+            recommendation = f"Normal volume ({total_count:,} logs). Error rate: {error_rate}%"
 
         # Build result
         result = {

--- a/sre-agent/.claude/skills/observability-splunk/scripts/sample_logs.py
+++ b/sre-agent/.claude/skills/observability-splunk/scripts/sample_logs.py
@@ -20,9 +20,26 @@ Examples:
 
 import argparse
 import json
+import re
 import sys
 
 from splunk_client import execute_search, format_log_entry
+
+# Only allow safe characters in SPL field values to prevent query injection.
+_SAFE_SPL_FIELD = re.compile(r"^[a-zA-Z0-9_\-.*]+$")
+
+_MAX_TIME_RANGE_MINUTES = 1440
+_MAX_LIMIT = 500
+
+
+def _validate_spl_field(value: str, field_name: str) -> str:
+    """Validate a value used in SPL field filters to prevent injection."""
+    if not _SAFE_SPL_FIELD.match(value):
+        raise ValueError(
+            f"Invalid {field_name} value: '{value}'. "
+            f"Only alphanumeric, underscore, hyphen, dot, and wildcard (*) are allowed."
+        )
+    return value
 
 
 def main():
@@ -58,16 +75,23 @@ def main():
     args = parser.parse_args()
 
     try:
-        # Build base search
+        # Enforce safety limits
+        if args.time_range > _MAX_TIME_RANGE_MINUTES:
+            raise ValueError(
+                f"Time range {args.time_range}m exceeds maximum ({_MAX_TIME_RANGE_MINUTES}m / 24h)."
+            )
+        args.limit = min(args.limit, _MAX_LIMIT)
+
+        # Build base search with validated fields
         search_parts = []
         if args.index:
-            search_parts.append(f"index={args.index}")
+            search_parts.append(f"index={_validate_spl_field(args.index, 'index')}")
         else:
             search_parts.append("index=*")
         if args.sourcetype:
-            search_parts.append(f"sourcetype={args.sourcetype}")
+            search_parts.append(f"sourcetype={_validate_spl_field(args.sourcetype, 'sourcetype')}")
         if args.host:
-            search_parts.append(f"host={args.host}")
+            search_parts.append(f"host={_validate_spl_field(args.host, 'host')}")
 
         # Apply strategy filter
         if args.strategy == "errors_only":
@@ -102,9 +126,7 @@ def main():
             logs.append(
                 {
                     "timestamp": result.get("_time"),
-                    "level": result.get("log_level")
-                    or result.get("severity")
-                    or "INFO",
+                    "level": result.get("log_level") or result.get("severity") or "INFO",
                     "sourcetype": result.get("sourcetype"),
                     "host": result.get("host"),
                     "source": result.get("source"),


### PR DESCRIPTION
## Summary

Observability scripts (Splunk, Loki, Datadog, Elasticsearch) and Azure Log Analytics accept user/agent-generated query parameters without validation, risking unbounded scans, query injection, and production impact.

This PR adds defense-in-depth safety guards at both the **code level** (input validation, result caps) and the **prompt level** (SKILL.md safety constraints):

- **Splunk** (`get_statistics.py`, `sample_logs.py`): Validate `index`/`sourcetype`/`host` fields against `[a-zA-Z0-9_\-.*]` whitelist; cap time range to 24h; cap result limit to 500
- **Loki** (`sample_logs.py`): Validate LogQL filter patterns against safe character whitelist; cap lookback to 7 days; cap result limit to 1000
- **Datadog** (`sample_logs.py`): Validate `service`/`host` facet values against safe character whitelist; cap time range to 24h; cap result limit to 1000
- **Azure Log Analytics** (`query_log_analytics.py`): Auto-append `| limit N` to KQL queries lacking limit/take/summarize clauses; default 1000 rows, max 10000; add `--max-results` CLI arg
- **Elasticsearch** (`elasticsearch_client.py`): Cap `search()` size parameter to 1000 to prevent cluster OOM
- **SKILL.md** (Splunk, Loki, Elasticsearch, Azure): Add "Safety Constraints" sections documenting query limits, time filters, and anti-patterns

## Motivation

These scripts are called by an AI agent that generates query parameters. Without validation:
- SPL injection: `--index "main | delete"` could execute destructive commands
- LogQL injection: `--filter '.*'` could match all logs across all streams
- Unbounded KQL: queries without `| limit` could return millions of rows
- Unbounded ES search: `size=100000` could OOM the Elasticsearch cluster

The existing PostgreSQL/MySQL database skills already have equivalent protections (read-only validation, multi-statement blocking). This PR brings observability skills to parity.

## Changes

| File | Change |
|------|--------|
| `observability-splunk/scripts/get_statistics.py` | Add `_validate_spl_field()`, time range cap (24h) |
| `observability-splunk/scripts/sample_logs.py` | Add `_validate_spl_field()`, time range cap, result limit (500) |
| `observability-loki/scripts/sample_logs.py` | Add `_validate_logql_filter()`, lookback cap (7d), result limit (1000) |
| `observability-datadog/scripts/sample_logs.py` | Add `_validate_dd_facet()`, time range cap (24h), result limit (1000) |
| `infrastructure-azure/scripts/query_log_analytics.py` | Add `_ensure_kql_limit()`, `--max-results` arg |
| `observability-elasticsearch/scripts/elasticsearch_client.py` | Cap `search()` size to 1000 |
| `observability-splunk/SKILL.md` | Add Safety Constraints section |
| `observability-loki/SKILL.md` | Add Safety Constraints section |
| `observability-elasticsearch/SKILL.md` | Add Safety Constraints section |
| `infrastructure-azure/SKILL.md` | Add Safety Constraints section |

## Test plan

- [x] `ruff check` passes on all modified Python files
- [x] `ruff format --check` passes on all modified Python files
- [ ] Splunk: valid `--index main` works; `--index "main | delete"` is rejected
- [ ] Loki: valid `--filter "error|exception"` works; `--filter '") } | line_format "injected"'` is rejected
- [ ] Datadog: valid `--service api` works; `--service "api OR *"` is rejected
- [ ] Azure: KQL without limit gets `| limit 1000` appended; KQL with existing `| limit 50` is unchanged
- [ ] Elasticsearch: `search(size=5000)` is silently capped to 1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)